### PR TITLE
chore: perform release 3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,10 @@
 .*
 !.git*
 
+target/
 */target/
-examples/*/target/
+*/*/target/
+
+# Release related
+pom.xml.releaseBackup
+release.properties

--- a/examples/locales-http-examples/pom.xml
+++ b/examples/locales-http-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.i18n</groupId>
     <artifactId>locales-oss-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/examples/locales-http-examples/pom.xml
+++ b/examples/locales-http-examples/pom.xml
@@ -1,12 +1,10 @@
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.spotify.i18n</groupId>
     <artifactId>locales-oss-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/examples/locales-http-examples/pom.xml
+++ b/examples/locales-http-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.i18n</groupId>
     <artifactId>locales-oss-parent</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/locales-common/pom.xml
+++ b/locales-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.spotify.i18n</groupId>
     <artifactId>locales-oss-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>locales-common</artifactId>

--- a/locales-common/pom.xml
+++ b/locales-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.spotify.i18n</groupId>
     <artifactId>locales-oss-parent</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.0</version>
   </parent>
 
   <artifactId>locales-common</artifactId>

--- a/locales-common/pom.xml
+++ b/locales-common/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.spotify.i18n</groupId>
     <artifactId>locales-oss-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
   </parent>
 
   <artifactId>locales-common</artifactId>

--- a/locales-utils/pom.xml
+++ b/locales-utils/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.spotify.i18n</groupId>
     <artifactId>locales-oss-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
   </parent>
 
   <artifactId>locales-utils</artifactId>

--- a/locales-utils/pom.xml
+++ b/locales-utils/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.spotify.i18n</groupId>
     <artifactId>locales-oss-parent</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.0</version>
   </parent>
 
   <artifactId>locales-utils</artifactId>

--- a/locales-utils/pom.xml
+++ b/locales-utils/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.spotify.i18n</groupId>
     <artifactId>locales-oss-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>locales-utils</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.spotify.i18n</groupId>
   <artifactId>locales-oss-parent</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -68,7 +68,7 @@
   <scm>
     <connection>scm:git:https@github.com:spotify/java-locales.git</connection>
     <developerConnection>scm:git:git@github.com:spotify/java-locales.git</developerConnection>
-    <tag>3.0.0</tag>
+    <tag>HEAD</tag>
     <url>http://github.com/spotify/java-locales</url>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.spotify.i18n</groupId>
   <artifactId>locales-oss-parent</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.0.0</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -68,7 +68,7 @@
   <scm>
     <connection>scm:git:https@github.com:spotify/java-locales.git</connection>
     <developerConnection>scm:git:git@github.com:spotify/java-locales.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v3.0.0</tag>
     <url>http://github.com/spotify/java-locales</url>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.spotify.i18n</groupId>
   <artifactId>locales-oss-parent</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -68,7 +68,7 @@
   <scm>
     <connection>scm:git:https@github.com:spotify/java-locales.git</connection>
     <developerConnection>scm:git:git@github.com:spotify/java-locales.git</developerConnection>
-    <tag>v3.0.0</tag>
+    <tag>HEAD</tag>
     <url>http://github.com/spotify/java-locales</url>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git@github.com:spotify/java-locales.git</connection>
+    <connection>scm:git:https@github.com:spotify/java-locales.git</connection>
     <developerConnection>scm:git:git@github.com:spotify/java-locales.git</developerConnection>
     <tag>HEAD</tag>
     <url>http://github.com/spotify/java-locales</url>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -12,7 +10,7 @@
 
   <groupId>com.spotify.i18n</groupId>
   <artifactId>locales-oss-parent</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -70,7 +68,7 @@
   <scm>
     <connection>scm:git:https@github.com:spotify/java-locales.git</connection>
     <developerConnection>scm:git:git@github.com:spotify/java-locales.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>3.0.0</tag>
     <url>http://github.com/spotify/java-locales</url>
   </scm>
 


### PR DESCRIPTION
This PR is the result of the execution of the following maven commands:

```shell
mvn release:clean release:prepare -DreleaseVersion=3.0.0
mvn release:perform
```

[Artifacts were deployed with version 3.0.0](https://central.sonatype.com/search?q=com.spotify.i18n)

This PR changes the following:
- new dev version is set to 3.0.1-SNAPSHOT
- .gitignore is updated to ignore release related files
- scm connection is switched from git to https