### PR TITLE
feat: add LocalesMatcher

### DIFF
--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/LocalesMatcher.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/LocalesMatcher.java
@@ -1,0 +1,40 @@
+/*-
+ * -\-\-
+ * locales-common
+ * --
+ * Copyright (C) 2016 - 2025 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.i18n.locales.common;
+
+import com.spotify.i18n.locales.common.model.LocalesMatcherResult;
+
+/**
+ * Represents an engine that performs match operations on a given input. All implementations of this
+ * interface must return a non-null {@link LocalesMatcherResult}, even when the given input is null
+ * or empty.
+ *
+ * @author Eric Fjøsne
+ */
+public interface LocalesMatcher {
+
+  /**
+   * Returns the {@link LocalesMatcherResult} for the given input
+   *
+   * @return the locales matcher result
+   */
+  LocalesMatcherResult match(final String input);
+}

--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/LocalesMatcherBaseImpl.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/LocalesMatcherBaseImpl.java
@@ -100,10 +100,10 @@ public abstract class LocalesMatcherBaseImpl implements LocalesMatcher {
   }
 
   private static int getDistanceBetweenInputAndSupported(
-      final LSR maxParsed, final LSR... maxSupported) {
+      final LSR maxParsed, final LSR maxSupported) {
     return LOCALE_DISTANCE_INSTANCE.getBestIndexAndDistance(
         maxParsed,
-        maxSupported,
+        new LSR[] {maxSupported},
         LOCALE_DISTANCE_SUPPORTED_LSRS_LENGTH,
         LOCALE_DISTANCE_SHIFTED,
         LOCALE_DISTANCE_FAVOR_SUBTAG,

--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/LocalesMatcherBaseImpl.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/LocalesMatcherBaseImpl.java
@@ -1,0 +1,146 @@
+/*-
+ * -\-\-
+ * locales-common
+ * --
+ * Copyright (C) 2016 - 2025 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.i18n.locales.common.impl;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.ibm.icu.impl.locale.LSR;
+import com.ibm.icu.impl.locale.LikelySubtags;
+import com.ibm.icu.impl.locale.LocaleDistance;
+import com.ibm.icu.util.LocaleMatcher.Direction;
+import com.ibm.icu.util.LocaleMatcher.FavorSubtag;
+import com.ibm.icu.util.ULocale;
+import com.spotify.i18n.locales.common.LocalesMatcher;
+import com.spotify.i18n.locales.common.model.LocalesMatcherResult;
+import com.spotify.i18n.locales.utils.languagetag.LanguageTagUtils;
+import java.util.Set;
+
+/**
+ * Base implementation of {@link LocalesMatcher} that attributes a matching score to a given input
+ * value (language tag) against a set of supported locales.
+ *
+ * <p>This class is not intended for public subclassing. New object instances must be created using
+ * the builder pattern, starting with the {@link #builder()} method.
+ *
+ * @author Eric Fjøsne
+ */
+@AutoValue
+public abstract class LocalesMatcherBaseImpl implements LocalesMatcher {
+
+  // Chosen max distance threshold. Anything beyond will be scored 0.
+  private static final double MAX_DISTANCE_THRESHOLD = 224.0;
+
+  // LocaleDistance.INSTANCE is commented as VisibleForTesting, so not ideal ... but this is the
+  // only way to make use of this class, which contains all we need here.
+  private static final LocaleDistance LOCALE_DISTANCE_INSTANCE = LocaleDistance.INSTANCE;
+
+  // LocaleDistance best distance arguments, all assigned to their default as per icu implementation
+  private static final int LOCALE_DISTANCE_SHIFTED =
+      LocaleDistance.shiftDistance(LOCALE_DISTANCE_INSTANCE.getDefaultScriptDistance());
+  private static final int LOCALE_DISTANCE_SUPPORTED_LSRS_LENGTH = 1;
+  private static final FavorSubtag LOCALE_DISTANCE_FAVOR_SUBTAG = FavorSubtag.LANGUAGE;
+  private static final Direction LOCALE_DISTANCE_DIRECTION = Direction.WITH_ONE_WAY;
+
+  // LikelySubtags.INSTANCE is commented as VisibleForTesting, so not ideal ... but this is the
+  // only way to make use of this class, which contains all we need here.
+  private static final LikelySubtags LIKELY_SUBTAGS_INSTANCE = LikelySubtags.INSTANCE;
+
+  // LikelySubtags method arguments, all assigned to their default as per icu implementation
+  private static final boolean LIKELY_SUBTAGS_CAN_RETURNS_INPUT = false;
+
+  public abstract Set<ULocale> supportedLocales();
+
+  @Override
+  public LocalesMatcherResult match(final String languageTag) {
+    return LocalesMatcherResult.builder()
+        .matchingScore(convertDistanceToScore(getBestDistance(languageTag)))
+        .build();
+  }
+
+  private int convertDistanceToScore(final int distance) {
+    if (distance > MAX_DISTANCE_THRESHOLD) {
+      return 0;
+    } else {
+      return (int) ((MAX_DISTANCE_THRESHOLD - distance) / MAX_DISTANCE_THRESHOLD * 100.0);
+    }
+  }
+
+  private int getBestDistance(final String languageTag) {
+    return LanguageTagUtils.parse(languageTag)
+        .map(LocalesMatcherBaseImpl::getMaximizedLanguageScriptRegion)
+        .map(
+            maxParsed ->
+                supportedLocales().stream()
+                    .map(LocalesMatcherBaseImpl::getMaximizedLanguageScriptRegion)
+                    .map(
+                        maxSupported ->
+                            getDistanceBetweenInputAndSupported(maxParsed, maxSupported))
+                    .map(Math::abs)
+                    .min(Integer::compare)
+                    .orElse(Integer.MAX_VALUE))
+        .orElse(Integer.MAX_VALUE);
+  }
+
+  private static int getDistanceBetweenInputAndSupported(
+      final LSR maxParsed, final LSR... maxSupported) {
+    return LOCALE_DISTANCE_INSTANCE.getBestIndexAndDistance(
+        maxParsed,
+        maxSupported,
+        LOCALE_DISTANCE_SUPPORTED_LSRS_LENGTH,
+        LOCALE_DISTANCE_SHIFTED,
+        LOCALE_DISTANCE_FAVOR_SUBTAG,
+        LOCALE_DISTANCE_DIRECTION);
+  }
+
+  private static LSR getMaximizedLanguageScriptRegion(final ULocale locale) {
+    return LIKELY_SUBTAGS_INSTANCE.makeMaximizedLsrFrom(locale, LIKELY_SUBTAGS_CAN_RETURNS_INPUT);
+  }
+
+  /**
+   * Returns a {@link Builder} instance that will allow you to manually create a {@link
+   * LocalesMatcherBaseImpl} instance.
+   *
+   * @return The builder
+   */
+  public static Builder builder() {
+    return new AutoValue_LocalesMatcherBaseImpl.Builder();
+  }
+
+  /** A builder for a {@link LocalesMatcherBaseImpl}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    Builder() {} // package private constructor
+
+    public abstract Builder supportedLocales(final Set<ULocale> baseLocales);
+
+    abstract LocalesMatcherBaseImpl autoBuild();
+
+    /** Builds a {@link LocalesMatcher} out of this builder. */
+    public final LocalesMatcher build() {
+      final LocalesMatcherBaseImpl built = autoBuild();
+      for (ULocale baseLocale : built.supportedLocales()) {
+        Preconditions.checkState(
+            !baseLocale.equals(ULocale.ROOT), "The supported locales cannot contain the root.");
+      }
+      return built;
+    }
+  }
+}

--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/LocalesMatcherBaseImpl.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/LocalesMatcherBaseImpl.java
@@ -64,7 +64,7 @@ public abstract class LocalesMatcherBaseImpl implements LocalesMatcher {
   private static final LikelySubtags LIKELY_SUBTAGS_INSTANCE = LikelySubtags.INSTANCE;
 
   // LikelySubtags method arguments, all assigned to their default as per icu implementation
-  private static final boolean LIKELY_SUBTAGS_CAN_RETURNS_INPUT = false;
+  private static final boolean LIKELY_SUBTAGS_RETURNS_INPUT_IF_UNMATCH = false;
 
   public abstract Set<ULocale> supportedLocales();
 
@@ -111,7 +111,8 @@ public abstract class LocalesMatcherBaseImpl implements LocalesMatcher {
   }
 
   private static LSR getMaximizedLanguageScriptRegion(final ULocale locale) {
-    return LIKELY_SUBTAGS_INSTANCE.makeMaximizedLsrFrom(locale, LIKELY_SUBTAGS_CAN_RETURNS_INPUT);
+    return LIKELY_SUBTAGS_INSTANCE.makeMaximizedLsrFrom(
+        locale, LIKELY_SUBTAGS_RETURNS_INPUT_IF_UNMATCH);
   }
 
   /**

--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/model/LocalesMatcherResult.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/model/LocalesMatcherResult.java
@@ -23,14 +23,10 @@ package com.spotify.i18n.locales.common.model;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.ibm.icu.util.ULocale;
-import com.spotify.i18n.locales.common.impl.LocalesMatcherBaseImpl.Builder;
+import com.spotify.i18n.locales.common.LocalesMatcher;
 
 /**
- * A model class that represents a resolved locale. It contains the resolved supported locale for
- * translations, along with the resolved locale for formatting.
- *
- * <p>By "supported locale", we mean that this is a locale that identifies a language for which we
- * can supply translations.
+ * A model class that represents a {@link LocalesMatcher} result.
  *
  * <p>This class is not intended for public subclassing. New object instances must be created using
  * the builder pattern, starting with the {@link #builder()} method.

--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/model/LocalesMatcherResult.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/model/LocalesMatcherResult.java
@@ -1,0 +1,85 @@
+/*-
+ * -\-\-
+ * locales-common
+ * --
+ * Copyright (C) 2016 - 2025 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.i18n.locales.common.model;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.ibm.icu.util.ULocale;
+import com.spotify.i18n.locales.common.impl.LocalesMatcherBaseImpl.Builder;
+
+/**
+ * A model class that represents a resolved locale. It contains the resolved supported locale for
+ * translations, along with the resolved locale for formatting.
+ *
+ * <p>By "supported locale", we mean that this is a locale that identifies a language for which we
+ * can supply translations.
+ *
+ * <p>This class is not intended for public subclassing. New object instances must be created using
+ * the builder pattern, starting with the {@link #builder()} method.
+ *
+ * @see ULocale
+ * @author Eric Fjøsne
+ */
+@AutoValue
+public abstract class LocalesMatcherResult {
+
+  private static final int MAX_SCORE = 100;
+  private static final int MIN_SCORE = 0;
+
+  public abstract int matchingScore();
+
+  /**
+   * Returns a {@link Builder} instance that will allow you to manually create a {@link
+   * LocalesMatcherResult} instance.
+   *
+   * @return The builder
+   */
+  public static Builder builder() {
+    return new AutoValue_LocalesMatcherResult.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    Builder() {} // package private constructor
+
+    public abstract Builder matchingScore(int matchingScore);
+
+    abstract LocalesMatcherResult autoBuild(); // not public
+
+    /**
+     * Builds a {@link LocalesMatcherResult} out of this builder.
+     *
+     * <p>This is safe to be called several times on the same builder.
+     *
+     * @throws IllegalStateException if any of the builder property does not match the requirements.
+     */
+    public final LocalesMatcherResult build() {
+      LocalesMatcherResult result = autoBuild();
+      int score = result.matchingScore();
+      Preconditions.checkState(
+          score >= MIN_SCORE && score <= MAX_SCORE,
+          String.format(
+              "The matching score must be between %d and %d. Provided: %d.",
+              MIN_SCORE, MAX_SCORE, score));
+      return result;
+    }
+  }
+}

--- a/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocalesMatcherBaseImplTest.java
+++ b/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocalesMatcherBaseImplTest.java
@@ -1,0 +1,128 @@
+/*-
+ * -\-\-
+ * locales-common
+ * --
+ * Copyright (C) 2016 - 2025 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.i18n.locales.common.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.ibm.icu.util.ULocale;
+import com.spotify.i18n.locales.common.LocalesMatcher;
+import com.spotify.i18n.locales.common.model.LocalesMatcherResult;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LocalesMatcherBaseImplTest {
+
+  @Test
+  void whenBuildingWithMissingRequiredProperties_buildFails() {
+    final IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> LocalesMatcherBaseImpl.builder().build());
+
+    assertEquals(thrown.getMessage(), "Missing required properties: supportedLocales");
+  }
+
+  @Test
+  void whenBuildingWithRootAsPartOfSupportedLocales_buildFails() {
+    final IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class,
+            () -> LocalesMatcherBaseImpl.builder().supportedLocales(Set.of(ULocale.ROOT)).build());
+
+    assertEquals(thrown.getMessage(), "The supported locales cannot contain the root.");
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void whenMatching_returnsExpectedResult(final String languageTag, final int expectedScore) {
+    final LocalesMatcher matcher =
+        LocalesMatcherBaseImpl.builder()
+            .supportedLocales(
+                Set.of("ar", "bs", "es", "fr", "ja", "pt", "sr-Latn", "zh-Hant").stream()
+                    .map(ULocale::forLanguageTag)
+                    .collect(Collectors.toSet()))
+            .build();
+
+    assertThat(
+        matcher.match(languageTag),
+        is(LocalesMatcherResult.builder().matchingScore(expectedScore).build()));
+  }
+
+  public static Stream<Arguments> whenMatching_returnsExpectedResult() {
+    return Stream.of(
+        // Edge cases
+        Arguments.of(" Invalid language tag ", 0),
+        Arguments.of(null, 0),
+
+        // Catalan should be matched, since we support Spanish
+        Arguments.of("ca", 28),
+        Arguments.of("ca-ES", 28), // Higher score for Spain than other countries
+        Arguments.of("ca-AD", 14),
+
+        // No english should be matched
+        Arguments.of("en", 0),
+        Arguments.of("en-GB", 0),
+        Arguments.of("en-US", 0),
+
+        // Spanish in Europe should be ranked higher
+        Arguments.of("es-419", 82),
+        Arguments.of("es-GB", 85),
+        Arguments.of("es-US", 82),
+
+        // Basque should be matched, since we support Spanish
+        Arguments.of("eu", 28),
+
+        // French
+        Arguments.of("fr", 100),
+        Arguments.of("fr-BE", 85),
+        Arguments.of("fr-CA", 85),
+        Arguments.of("fr-FR", 99),
+
+        // Galician should be matched, since we support Spanish
+        Arguments.of("gl", 28),
+
+        // Hindi shouldn't be matched
+        Arguments.of("hi", 0),
+
+        // Croatian should be nicely matched with Bosnian
+        Arguments.of("hr-HR", 71),
+
+        // Serbian Cyrillic should be matched, although only Latin script is supported
+        Arguments.of("sr", 82),
+        Arguments.of("sr-Latn", 100),
+
+        // Portuguese
+        Arguments.of("pt", 100),
+        Arguments.of("pt-BR", 99),
+        Arguments.of("pt-SE", 82),
+        Arguments.of("pt-US", 85),
+
+        // Only Traditional Chinese should be matched, not Simplified
+        Arguments.of("zh-CN", 0),
+        Arguments.of("zh-TW", 98),
+        Arguments.of("zh-HK", 82));
+  }
+}

--- a/locales-common/src/test/java/com/spotify/i18n/locales/common/model/LocalesMatcherResultTest.java
+++ b/locales-common/src/test/java/com/spotify/i18n/locales/common/model/LocalesMatcherResultTest.java
@@ -1,0 +1,59 @@
+/*-
+ * -\-\-
+ * locales-common
+ * --
+ * Copyright (C) 2016 - 2025 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.i18n.locales.common.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class LocalesMatcherResultTest {
+
+  @Test
+  void whenBuildingWithMissingRequiredProperties_buildFails() {
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> LocalesMatcherResult.builder().build());
+
+    assertEquals("Missing required properties: matchingScore", thrown.getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-128, -4, -1, 101, 10348})
+  void whenProvidedScoreIsInvalid_buildFails(int invalidScore) {
+    IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class,
+            () -> LocalesMatcherResult.builder().matchingScore(invalidScore).build());
+
+    assertEquals(
+        String.format("The matching score must be between 0 and 100. Provided: %d.", invalidScore),
+        thrown.getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 42, 100})
+  void whenProvidedScoreIsValid_succeeds(int validScore) {
+    assertEquals(
+        validScore,
+        LocalesMatcherResult.builder().matchingScore(validScore).build().matchingScore());
+  }
+}


### PR DESCRIPTION
We need a new helper to make sense of how well a given locale matches a set of supported locales.

For this, we introduce a new `LocalesMatcher` interface, which returns a `LocalesMatcherResult` with a `matchingScore` between 0 and 100.

This is making use of icu4j `LocaleDistance` implementation, which is supposed to be private. The proposed implementation seems to be the only way to get the information we need, without having to re-implement the whole logic.