### PR TITLE
fix: Wrong parent locale returned by hierarchy util

### DIFF
--- a/locales-utils/src/test/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtilsTest.java
+++ b/locales-utils/src/test/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtilsTest.java
@@ -91,20 +91,20 @@ class LocalesHierarchyUtilsTest {
   }
 
   static Stream<Arguments> getParentLocale() {
-    return Map.of(
-            "en-150", "en-001",
-            "en-GB", "en-001",
-            "en-US", "en",
-            "fr", "",
-            "ja-JP", "ja",
-            "wo-Arab", "",
-            "zh-Hans", "zh",
-            "zh-Hant", "",
-            "ht", "fr-HT",
-            "zh-Hant-MO", "zh-Hant-HK")
-        .entrySet()
-        .stream()
-        .map(e -> Arguments.arguments(e.getKey(), e.getValue()));
+    return Stream.of(
+        Arguments.of("en-150", "en-001"),
+        Arguments.of("en-GB", "en-001"),
+        Arguments.of("en-US", "en"),
+        Arguments.of("fr", ""),
+        Arguments.of("ja-JP", "ja"),
+        Arguments.of("wo-Arab", ""),
+        Arguments.of("zh-CN", "zh"),
+        Arguments.of("zh-TW", "zh-Hant"),
+        Arguments.of("zh-MO", "zh-Hant-HK"),
+        Arguments.of("zh-Hans", "zh"),
+        Arguments.of("zh-Hant", ""),
+        Arguments.of("ht", "fr-HT"),
+        Arguments.of("zh-Hant-MO", "zh-Hant-HK"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
The current implementation of a parent locale makes use of
- [The list of explicit parents defined as per CLDR](https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/parentLocales.json)
- [The fallback to the given locale](https://unicode-org.github.io/icu-docs/apidoc/dev/icu4j/com/ibm/icu/util/ULocale.html#getFallback--)
 
The problem with this relates to the fact that some identifiers, like `zh-TW` or `zh-MO`, have an implicit script attached (`Hant`, for Chinese Traditional), which is therefore omitted.

The fallback logic consists of the removal of the last identifier present in the language tag. In this case, `zh-TW`'s parent would be calculated as `zh`, which is Chinese Simplified and therefore the wrong parent. The right calculated parent of `zh-TW` should be `zh-Hant`.

The proposed fix is to maximize the given locale to all of its likely subtag, do the same for its fallback, and ensure that the scripts are a match. If not, we calculate the parent of the transformed locale (e.g.: `zh-Hant-TW`) based on the given one (e.g.: `zh-TW`), enriched with its likely script tag (e.g. `Hant`).