### PR TITLE
fix: locales-utils: Only maximize locale when required

### DIFF
--- a/locales-utils/src/main/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtils.java
+++ b/locales-utils/src/main/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtils.java
@@ -25,11 +25,13 @@ import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.ULocale.Builder;
 import com.spotify.i18n.locales.utils.available.AvailableLocalesUtils;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -44,6 +46,13 @@ public class LocalesHierarchyUtils {
 
   private static final Map<ULocale, ULocale> CHILD_TO_PARENT_MAP =
       generateSpecialCldrChildToParentsMap();
+
+  /** Set of language codes for which the script is a differentiator in CLDR */
+  static final Set<String> LANGUAGE_CODES_WITH_MULTIPLE_SCRIPTS_IN_CLDR =
+      Arrays.stream(ULocale.getAvailableLocales())
+          .filter(locale -> !locale.getScript().isEmpty())
+          .map(ULocale::getLanguage)
+          .collect(Collectors.toSet());
 
   /**
    * Returns the {@link Set} of all {@link ULocale}s that are descendants of the given locale,
@@ -176,8 +185,7 @@ public class LocalesHierarchyUtils {
 
   /**
    * Returns the parent {@link ULocale} according to CLDR, for a given locale, based on its
-   * fallback. We need this to handle cases like zh-TW, for which the parent locale should be
-   * zh-Hant and not zh. By default, the fallback logic removes the last identifier from the tag.
+   * fallback. By default, the fallback logic removes the last identifier from the tag.
    *
    * @param locale A locale for which no explicit parent mapping is defined in CLDR
    * @return The parent locale, according to CLDR
@@ -187,35 +195,83 @@ public class LocalesHierarchyUtils {
       return Optional.empty();
     } else if (isSameLocale(locale.getFallback(), ULocale.ROOT)) {
       return Optional.of(ULocale.ROOT);
+    } else if (scriptIsMajorLanguageDifferentiator(locale)) {
+      return getParentLocaleBasedOnLocaleAndScript(locale);
     } else {
-      // We retrieve the script from the given locale
-      final String localeScript = ULocale.addLikelySubtags(locale).getScript();
-      // We retrieve the script from the fallback locale
-      final String parentLocaleScript = ULocale.addLikelySubtags(locale.getFallback()).getScript();
-
-      if (localeScript.equals(parentLocaleScript)) {
-        // If they are a match, we can safely return the fallback.
+      // When the script isn't a major differentiator, we can confidently return the fallback
+      // property of the given locale as parent locale when it doesn't contain any script code.
+      // Otherwise, we assess the parent locale based on the locale script, to prevent unavailable
+      // locales like es-Arab from being considered.
+      if (locale.getScript().isEmpty()) {
         return Optional.of(locale.getFallback());
       } else {
-        final ULocale localeWithScriptOverride =
-            new Builder()
-                // Build with the base language tag
-                .setLanguageTag(locale.toLanguageTag())
-                // Override the script only
-                .setScript(localeScript)
-                .build();
-        if (isSameLocale(locale, localeWithScriptOverride)) {
-          // This is most likely a locale that is not available in CLDR, with a wrong combination
-          // of language code and script code.
-          return Optional.empty();
-        } else {
-          // When they are not a match, we call the same method by force-feeding the script
-          // identifier to the given locale. Ex: for zh-TW, we will be calling this same method,
-          // with the overridden zh-Hant-TW locale.
-          return getParentLocale(localeWithScriptOverride);
-        }
+        return getParentLocaleBasedOnLocaleAndScript(locale);
       }
     }
+  }
+
+  /**
+   * Returns a flag on whether the given locale identifies a language for which the script can be a
+   * language differentiator.
+   *
+   * @param locale any locale
+   * @return boolean value
+   */
+  private static boolean scriptIsMajorLanguageDifferentiator(final ULocale locale) {
+    return LANGUAGE_CODES_WITH_MULTIPLE_SCRIPTS_IN_CLDR.contains(locale.getLanguage());
+  }
+
+  /**
+   * Returns the parent {@link ULocale} according to CLDR, for a given locale for which the script
+   * can be a language differentiator, based on its fallback. We need this to handle cases like
+   * zh-TW, for which the parent locale should be zh-Hant and not zh. By default, the fallback logic
+   * removes the last identifier from the tag.
+   *
+   * @param locale A locale for which no explicit parent mapping is defined in CLDR
+   * @return The parent locale, according to CLDR
+   */
+  private static Optional<ULocale> getParentLocaleBasedOnLocaleAndScript(final ULocale locale) {
+    // We retrieve the script from the given locale
+    final String localeScript = getLocaleScript(locale);
+    // We retrieve the script from the fallback locale
+    final String parentLocaleScript = getLocaleScript(locale.getFallback());
+
+    if (localeScript.equals(parentLocaleScript)) {
+      // If they are a match, we can safely return the fallback.
+      return Optional.of(locale.getFallback());
+    } else {
+      final ULocale localeWithScriptOverride =
+          new Builder()
+              // Build with the base language tag
+              .setLanguageTag(locale.toLanguageTag())
+              // Override the script only
+              .setScript(localeScript)
+              .build();
+      if (isSameLocale(locale, localeWithScriptOverride)) {
+        // This is most likely a locale that is not available in CLDR, with a wrong combination
+        // of language code and script code.
+        return Optional.empty();
+      } else {
+        // When they are not a match, we call the same method by force-feeding the script
+        // identifier to the given locale. Ex: for zh-TW, we will be calling this same method,
+        // with the overridden zh-Hant-TW locale.
+        return getParentLocale(localeWithScriptOverride);
+      }
+    }
+  }
+
+  /**
+   * Returns a given locale script
+   *
+   * @param locale
+   * @return
+   */
+  private static String getLocaleScript(final ULocale locale) {
+    // We only calculate the script if it isn't yet present in the locale.
+    return Optional.of(locale)
+        .map(ULocale::getScript)
+        .filter(Predicate.not(String::isEmpty))
+        .orElseGet(() -> ULocale.addLikelySubtags(locale).getScript());
   }
 
   /**

--- a/locales-utils/src/test/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtilsTest.java
+++ b/locales-utils/src/test/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtilsTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.i18n.locales.utils.hierarchy;
 
+import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.LANGUAGE_CODES_WITH_MULTIPLE_SCRIPTS_IN_CLDR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,6 +42,22 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class LocalesHierarchyUtilsTest {
+
+  @Test
+  void languageCodesWithMultipleScriptsInCldr() {
+    final Set<String> expectedLanguageCodesWithMultipleScriptsInCldr =
+        Set.of(
+            "az", "bs", "ff", "hi", "ks", "kxv", "mni", "pa", "sat", "sd", "shi", "sr", "su", "uz",
+            "vai", "yue", "zh");
+
+    assertEquals(
+        expectedLanguageCodesWithMultipleScriptsInCldr.size(),
+        LANGUAGE_CODES_WITH_MULTIPLE_SCRIPTS_IN_CLDR.size());
+
+    expectedLanguageCodesWithMultipleScriptsInCldr.forEach(
+        languageCode ->
+            assertTrue(LANGUAGE_CODES_WITH_MULTIPLE_SCRIPTS_IN_CLDR.contains(languageCode)));
+  }
 
   @ParameterizedTest
   @MethodSource


### PR DESCRIPTION
Maximizing the locale (via `ULocale.addLikelySubtags`) might actually an operation that might be costly, and could cause performance issues.

This PR adjusts the logic to ensure that it is only executed when required.

We consider this as a fix as it might cause performance issues in production, because of the introduced delays.