### PR TITLE
chore: Update icu4j to 77.1

### DIFF
--- a/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocalesResolverBaseImplTest.java
+++ b/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocalesResolverBaseImplTest.java
@@ -322,7 +322,7 @@ class LocalesResolverBaseImplTest {
         Arguments.of("gn-PY", "es-419", List.of("es"), "es-PY"),
         Arguments.of("kk-KZ", "ru", Collections.emptyList(), "ru-KZ"),
         Arguments.of("mn-MN", "ru", Collections.emptyList(), "ru-RU"),
-        Arguments.of("nso-ZA", "en-GB", List.of("en"), "en-ZA"),
+        Arguments.of("nso-ZA", "en", Collections.emptyList(), "en-ZA"),
         Arguments.of("sq-XK", "en", Collections.emptyList(), "en-US"),
         Arguments.of("sr-Latn-XK", "sr-Latn", Collections.emptyList(), "sr-Latn-XK"),
         Arguments.of("sr-XK", "sr-Latn", Collections.emptyList(), "sr-Latn-XK"));

--- a/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/ReferenceLocalesCalculatorBaseImplTest.java
+++ b/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/ReferenceLocalesCalculatorBaseImplTest.java
@@ -154,6 +154,7 @@ class ReferenceLocalesCalculatorBaseImplTest {
         REFERENCE_LOCALES_CALCULATOR.calculateRelatedReferenceLocales(input);
     assertTrue(
         expectedRelatedReferenceLocales.stream().allMatch(relatedReferenceLocales::contains));
+    assertEquals(expectedRelatedReferenceLocales.size(), relatedReferenceLocales.size());
   }
 
   public static Stream<Arguments> whenCalculatingRelatedReferenceLocales_returnsExpected() {
@@ -184,10 +185,10 @@ class ReferenceLocalesCalculatorBaseImplTest {
   public static Stream<Arguments> whenCalculatingBestMatchingLocale_returnsExpected() {
     return Stream.of(
         Arguments.of("zh-Hans-CN", "zh"),
-        Arguments.of("ZH_us", "zh-TW"),
+        Arguments.of("ZH_us", "zh-Hant-MY"),
         Arguments.of("zh-Hant", "zh-TW"),
         Arguments.of("zh-Hant-HK", "zh-HK"),
-        Arguments.of("zh-Hant-CN", "zh-TW"),
+        Arguments.of("zh-Hant-CN", "zh-Hant-MY"),
         Arguments.of("fr-Latn-FR", "fr"),
         Arguments.of("fr-BE", "fr-BE"),
         Arguments.of("sr-RS", "sr"),
@@ -209,8 +210,11 @@ class ReferenceLocalesCalculatorBaseImplTest {
         rrl("zh-HK", SAME_OR_INTERCHANGEABLE),
         rrl("zh-MO", SAME_OR_INTERCHANGEABLE),
         rrl("zh-TW", SAME_OR_INTERCHANGEABLE),
+        rrl("zh-Hant-MY", SAME_OR_INTERCHANGEABLE),
         // Cantonese
-        rrl("yue", HIGH));
+        rrl("yue", HIGH),
+        rrl("yue-MO", HIGH),
+        rrl("yue-Hant-CN", HIGH));
   }
 
   private static List<RelatedReferenceLocale> danish() {
@@ -230,6 +234,9 @@ class ReferenceLocalesCalculatorBaseImplTest {
 
   private static List<RelatedReferenceLocale> english() {
     return List.of(
+        // Afrikaans
+        rrl("af", LOW),
+        rrl("af-NA", LOW),
         // Welsh
         rrl("cy", LOW),
         // English
@@ -256,16 +263,20 @@ class ReferenceLocalesCalculatorBaseImplTest {
         rrl("en-CM", SAME_OR_INTERCHANGEABLE),
         rrl("en-CX", SAME_OR_INTERCHANGEABLE),
         rrl("en-CY", SAME_OR_INTERCHANGEABLE),
+        rrl("en-CZ", SAME_OR_INTERCHANGEABLE),
         rrl("en-DE", SAME_OR_INTERCHANGEABLE),
         rrl("en-DG", SAME_OR_INTERCHANGEABLE),
         rrl("en-DK", SAME_OR_INTERCHANGEABLE),
         rrl("en-DM", SAME_OR_INTERCHANGEABLE),
         rrl("en-ER", SAME_OR_INTERCHANGEABLE),
+        rrl("en-ES", SAME_OR_INTERCHANGEABLE),
         rrl("en-FI", SAME_OR_INTERCHANGEABLE),
         rrl("en-FJ", SAME_OR_INTERCHANGEABLE),
+        rrl("en-FR", SAME_OR_INTERCHANGEABLE),
         rrl("en-FK", SAME_OR_INTERCHANGEABLE),
         rrl("en-FM", SAME_OR_INTERCHANGEABLE),
         rrl("en-GB", SAME_OR_INTERCHANGEABLE),
+        rrl("en-GS", SAME_OR_INTERCHANGEABLE),
         rrl("en-GD", SAME_OR_INTERCHANGEABLE),
         rrl("en-GG", SAME_OR_INTERCHANGEABLE),
         rrl("en-GH", SAME_OR_INTERCHANGEABLE),
@@ -274,12 +285,14 @@ class ReferenceLocalesCalculatorBaseImplTest {
         rrl("en-GU", SAME_OR_INTERCHANGEABLE),
         rrl("en-GY", SAME_OR_INTERCHANGEABLE),
         rrl("en-HK", SAME_OR_INTERCHANGEABLE),
+        rrl("en-HU", SAME_OR_INTERCHANGEABLE),
         rrl("en-ID", SAME_OR_INTERCHANGEABLE),
         rrl("en-IE", SAME_OR_INTERCHANGEABLE),
         rrl("en-IL", SAME_OR_INTERCHANGEABLE),
         rrl("en-IM", SAME_OR_INTERCHANGEABLE),
         rrl("en-IN", SAME_OR_INTERCHANGEABLE),
         rrl("en-IO", SAME_OR_INTERCHANGEABLE),
+        rrl("en-IT", SAME_OR_INTERCHANGEABLE),
         rrl("en-JE", SAME_OR_INTERCHANGEABLE),
         rrl("en-JM", SAME_OR_INTERCHANGEABLE),
         rrl("en-KE", SAME_OR_INTERCHANGEABLE),
@@ -303,15 +316,19 @@ class ReferenceLocalesCalculatorBaseImplTest {
         rrl("en-NF", SAME_OR_INTERCHANGEABLE),
         rrl("en-NG", SAME_OR_INTERCHANGEABLE),
         rrl("en-NL", SAME_OR_INTERCHANGEABLE),
+        rrl("en-NO", SAME_OR_INTERCHANGEABLE),
         rrl("en-NR", SAME_OR_INTERCHANGEABLE),
         rrl("en-NU", SAME_OR_INTERCHANGEABLE),
         rrl("en-NZ", SAME_OR_INTERCHANGEABLE),
         rrl("en-PG", SAME_OR_INTERCHANGEABLE),
         rrl("en-PH", SAME_OR_INTERCHANGEABLE),
         rrl("en-PK", SAME_OR_INTERCHANGEABLE),
+        rrl("en-PL", SAME_OR_INTERCHANGEABLE),
         rrl("en-PN", SAME_OR_INTERCHANGEABLE),
         rrl("en-PR", SAME_OR_INTERCHANGEABLE),
+        rrl("en-PT", SAME_OR_INTERCHANGEABLE),
         rrl("en-PW", SAME_OR_INTERCHANGEABLE),
+        rrl("en-RO", SAME_OR_INTERCHANGEABLE),
         rrl("en-RW", SAME_OR_INTERCHANGEABLE),
         rrl("en-SB", SAME_OR_INTERCHANGEABLE),
         rrl("en-SC", SAME_OR_INTERCHANGEABLE),
@@ -320,6 +337,7 @@ class ReferenceLocalesCalculatorBaseImplTest {
         rrl("en-SG", SAME_OR_INTERCHANGEABLE),
         rrl("en-SH", SAME_OR_INTERCHANGEABLE),
         rrl("en-SI", SAME_OR_INTERCHANGEABLE),
+        rrl("en-SK", SAME_OR_INTERCHANGEABLE),
         rrl("en-SL", SAME_OR_INTERCHANGEABLE),
         rrl("en-SS", SAME_OR_INTERCHANGEABLE),
         rrl("en-SX", SAME_OR_INTERCHANGEABLE),

--- a/locales-utils/src/main/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtils.java
+++ b/locales-utils/src/main/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtils.java
@@ -284,7 +284,7 @@ public class LocalesHierarchyUtils {
    * by the {@link ULocale#getFallback()} method, according to CLDR.
    *
    * <p>The list of special parents used here is based on the linked json file below, as it existed
-   * for commit ff1f2a4 from Apr 4 2024.
+   * for commit 30c5cce from Feb 4 2025.
    *
    * @see <a
    *     href="https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/parentLocales.json">parentLocales.json</a>
@@ -318,6 +318,7 @@ public class LocalesHierarchyUtils {
     map.put("en-GH", "en-001");
     map.put("en-GI", "en-001");
     map.put("en-GM", "en-001");
+    map.put("en-GS", "en-001");
     map.put("en-GY", "en-001");
     map.put("en-HK", "en-001");
     map.put("en-ID", "en-001");
@@ -380,12 +381,22 @@ public class LocalesHierarchyUtils {
     map.put("en-AT", "en-150");
     map.put("en-BE", "en-150");
     map.put("en-CH", "en-150");
+    map.put("en-CZ", "en-150");
     map.put("en-DE", "en-150");
     map.put("en-DK", "en-150");
+    map.put("en-ES", "en-150");
     map.put("en-FI", "en-150");
+    map.put("en-FR", "en-150");
+    map.put("en-HU", "en-150");
+    map.put("en-IT", "en-150");
     map.put("en-NL", "en-150");
+    map.put("en-NO", "en-150");
+    map.put("en-PL", "en-150");
+    map.put("en-PT", "en-150");
+    map.put("en-RO", "en-150");
     map.put("en-SE", "en-150");
     map.put("en-SI", "en-150");
+    map.put("en-SK", "en-150");
     map.put("hi-Latn", "en-IN");
     map.put("es-AR", "es-419");
     map.put("es-BO", "es-419");
@@ -441,7 +452,9 @@ public class LocalesHierarchyUtils {
     map.put("ff-Arab", "und");
     map.put("ha-Arab", "und");
     map.put("iu-Latn", "und");
+    map.put("kaa-Latn", "und");
     map.put("kk-Arab", "und");
+    map.put("kok-Latn", "und");
     map.put("ks-Deva", "und");
     map.put("ku-Arab", "und");
     map.put("kxv-Deva", "und");

--- a/locales-utils/src/test/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtilsTest.java
+++ b/locales-utils/src/test/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtilsTest.java
@@ -47,8 +47,8 @@ class LocalesHierarchyUtilsTest {
   void languageCodesWithMultipleScriptsInCldr() {
     final Set<String> expectedLanguageCodesWithMultipleScriptsInCldr =
         Set.of(
-            "az", "bs", "ff", "hi", "ks", "kxv", "mni", "pa", "sat", "sd", "shi", "sr", "su", "uz",
-            "vai", "yue", "zh");
+            "az", "bs", "ff", "hi", "kk", "kok", "ks", "kxv", "mni", "pa", "sat", "sd", "shi", "sr",
+            "su", "uz", "vai", "yue", "zh");
 
     assertEquals(
         expectedLanguageCodesWithMultipleScriptsInCldr.size(),
@@ -78,9 +78,9 @@ class LocalesHierarchyUtilsTest {
             "fr",
             "fr-BE,fr-BF,fr-BI,fr-BJ,fr-BL,fr-CA,fr-CD,fr-CF,fr-CG,fr-CH,fr-CI,fr-CM,fr-DJ,fr-DZ,fr-FR,fr-GA,fr-GF,fr-GN,fr-GP,fr-GQ,fr-HT,fr-KM,fr-LU,fr-MA,fr-MC,fr-MF,fr-MG,fr-ML,fr-MQ,fr-MR,fr-MU,fr-NC,fr-NE,fr-PF,fr-PM,fr-RE,fr-RW,fr-SC,fr-SN,fr-SY,fr-TD,fr-TG,fr-TN,fr-VU,fr-WF,fr-YT",
             "en",
-            "en-001,en-150,en-AE,en-AG,en-AI,en-AS,en-AT,en-AU,en-BB,en-BE,en-BI,en-BM,en-BS,en-BW,en-BZ,en-CA,en-CC,en-CH,en-CK,en-CM,en-CX,en-CY,en-DE,en-DG,en-DK,en-DM,en-ER,en-FI,en-FJ,en-FK,en-FM,en-GB,en-GD,en-GG,en-GH,en-GI,en-GM,en-GU,en-GY,en-HK,en-ID,en-IE,en-IL,en-IM,en-IN,en-IO,en-JE,en-JM,en-KE,en-KI,en-KN,en-KY,en-LC,en-LR,en-LS,en-MG,en-MH,en-MO,en-MP,en-MS,en-MT,en-MU,en-MV,en-MW,en-MY,en-NA,en-NF,en-NG,en-NL,en-NR,en-NU,en-NZ,en-PG,en-PH,en-PK,en-PN,en-PR,en-PW,en-RW,en-SB,en-SC,en-SD,en-SE,en-SG,en-SH,en-SI,en-SL,en-SS,en-SX,en-SZ,en-TC,en-TK,en-TO,en-TT,en-TV,en-TZ,en-UG,en-UM,en-US,en-VC,en-VG,en-VI,en-VU,en-WS,en-ZA,en-ZM,en-ZW,hi-Latn,hi-Latn-IN",
+            "en-001,en-150,en-AE,en-AG,en-AI,en-AS,en-AT,en-AU,en-BB,en-BE,en-BI,en-BM,en-BS,en-BW,en-BZ,en-CA,en-CC,en-CH,en-CK,en-CM,en-CX,en-CY,en-CZ,en-DE,en-DG,en-DK,en-DM,en-ER,en-ES,en-FI,en-FJ,en-FK,en-FM,en-FR,en-GB,en-GD,en-GG,en-GH,en-GI,en-GM,en-GS,en-GU,en-GY,en-HK,en-HU,en-ID,en-IE,en-IL,en-IM,en-IN,en-IO,en-IT,en-JE,en-JM,en-KE,en-KI,en-KN,en-KY,en-LC,en-LR,en-LS,en-MG,en-MH,en-MO,en-MP,en-MS,en-MT,en-MU,en-MV,en-MW,en-MY,en-NA,en-NF,en-NG,en-NL,en-NO,en-NR,en-NU,en-NZ,en-PG,en-PH,en-PK,en-PL,en-PN,en-PR,en-PT,en-PW,en-RO,en-RW,en-SB,en-SC,en-SD,en-SE,en-SG,en-SH,en-SI,en-SK,en-SL,en-SS,en-SX,en-SZ,en-TC,en-TK,en-TO,en-TT,en-TV,en-TZ,en-UG,en-UM,en-US,en-VC,en-VG,en-VI,en-VU,en-WS,en-ZA,en-ZM,en-ZW,hi-Latn,hi-Latn-IN",
             "zh-Hant",
-            "zh-Hant-HK,zh-Hant-MO,zh-Hant-TW")
+            "zh-Hant-HK,zh-Hant-MO,zh-Hant-MY,zh-Hant-TW")
         .entrySet()
         .stream()
         .map(e -> Arguments.arguments(e.getKey(), e.getValue()));

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
     <google.auto-value.version>1.11.0</google.auto-value.version>
     <google.guava.version>33.3.1-jre</google.guava.version>
-    <icu4j.version>75.1</icu4j.version>
+    <icu4j.version>77.1</icu4j.version>
     <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
     <junit.version>5.11.3</junit.version>
     <mockito.version>5.12.0</mockito.version>


### PR DESCRIPTION
We want this repo to make use of the latest version of icu4j.

This PR:
- Updates icu4j to latest version: 77.1
- Adjusts unit tests to reflect the locale data changes introduced between icu4j 75.1 and 77.1.
- Updates the definition of special parent locales, as defined in the original CLDR code repository.