### PR TITLE
fix: Fix flaky behavior in LocaleMatcher

### DIFF
--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/ReferenceLocalesCalculatorBaseImpl.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/ReferenceLocalesCalculatorBaseImpl.java
@@ -31,6 +31,7 @@ import com.spotify.i18n.locales.utils.available.AvailableLocalesUtils;
 import com.spotify.i18n.locales.utils.languagetag.LanguageTagUtils;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -52,7 +53,10 @@ public abstract class ReferenceLocalesCalculatorBaseImpl implements ReferenceLoc
   /** Prepared {@link LocaleMatcher}, ready to find the best matching reference locale */
   private static final LocaleMatcher REFERENCE_LOCALE_MATCHER =
       LocaleMatcher.builder()
-          .setSupportedULocales(AvailableLocalesUtils.getReferenceLocales())
+          .setSupportedULocales(
+              AvailableLocalesUtils.getReferenceLocales().stream()
+                  .sorted(Comparator.comparing(ULocale::toLanguageTag))
+                  .collect(Collectors.toList()))
           .setNoDefaultLocale()
           .build();
 


### PR DESCRIPTION
The project build is failing on a given unit test:

https://github.com/spotify/java-locales/blob/main/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/ReferenceLocalesCalculatorBaseImplTest.java#L176-L197

The `ZH_us` and `zh-Hant-CN` are resolved sometimes to `zh-TW`, sometimes to `zh-Hant-MY`. This seems to be related to the fact that the list of supported locales, configured in the related LocaleMatcher, is passed as a HashSet, meaning ordering of values is not guaranteed.

It might just be that the distance between `zh-TW` and `zh-Hant-MY`, compared to these 2 test values, is the exact same, resulting in flaky behavior.

From a functional requirements perspective, it doesn't matter whether this method returns `zh-TW` or `zh-Hant-MY`, as this logic is  ultimately meant to calculate affinity between locales, which will result in the same value whether it returns `zh-TW`, or `zh-Hant-MY`.

We need to report this to Unicode, but in the meantime suggest working around the issue by passing a list of ordered locales to the LocaleMatcher.