### PR TITLE
feat: Add isRootLocale method to LocalesHierarchyUtils

### DIFF
--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/LocaleAffinityCalculatorBaseImpl.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/LocaleAffinityCalculatorBaseImpl.java
@@ -20,7 +20,7 @@
 
 package com.spotify.i18n.locales.common.impl;
 
-import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isSameLocale;
+import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isRootLocale;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
@@ -184,7 +184,7 @@ public abstract class LocaleAffinityCalculatorBaseImpl implements LocaleAffinity
       final LocaleAffinityCalculatorBaseImpl built = autoBuild();
       for (ULocale locale : built.againstLocales()) {
         Preconditions.checkState(
-            !isSameLocale(locale, ULocale.ROOT),
+            !isRootLocale(locale),
             "The locales against which affinity needs to be calculated cannot contain the root.");
       }
       return built;

--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/model/ResolvedLocale.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/model/ResolvedLocale.java
@@ -20,6 +20,9 @@
 
 package com.spotify.i18n.locales.common.model;
 
+import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isRootLocale;
+import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isSameLocale;
+
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.ibm.icu.util.ULocale;
@@ -208,7 +211,7 @@ public abstract class ResolvedLocale {
 
     private static void validateLocaleForTranslations(ResolvedLocale resolvedLocale) {
       Preconditions.checkState(
-          !resolvedLocale.localeForTranslations().equals(ULocale.ROOT),
+          !isRootLocale(resolvedLocale.localeForTranslations()),
           "The given localeForTranslations cannot be the root.");
 
       Preconditions.checkState(
@@ -224,15 +227,12 @@ public abstract class ResolvedLocale {
 
       Preconditions.checkState(
           !resolvedLocale.localeForTranslationsFallbacks().stream()
-              .anyMatch(locale -> LocalesHierarchyUtils.isSameLocale(locale, ULocale.ROOT)),
+              .anyMatch(locale -> isRootLocale(locale)),
           "The given fallbackLocalesForTranslations cannot contain the root.");
 
       Preconditions.checkState(
           !resolvedLocale.localeForTranslationsFallbacks().stream()
-              .anyMatch(
-                  locale ->
-                      LocalesHierarchyUtils.isSameLocale(
-                          locale, resolvedLocale.localeForTranslations())),
+              .anyMatch(locale -> isSameLocale(locale, resolvedLocale.localeForTranslations())),
           "The given fallbackLocalesForTranslations cannot contain the localeForTranslations [%s].",
           resolvedLocale.localeForTranslations().toLanguageTag());
 
@@ -256,7 +256,7 @@ public abstract class ResolvedLocale {
           resolvedLocale.localeForTranslationsFallbacks().stream()
               .filter(
                   locale ->
-                      !LocalesHierarchyUtils.isSameLocale(
+                      !isSameLocale(
                           localeForTranslationsHighestAncestor,
                           LocalesHierarchyUtils.getHighestAncestorLocale(locale)))
               .collect(Collectors.toList());
@@ -273,7 +273,7 @@ public abstract class ResolvedLocale {
 
     private static void validateLocaleForFormatting(ResolvedLocale resolvedLocale) {
       Preconditions.checkState(
-          !resolvedLocale.localeForFormatting().equals(ULocale.ROOT),
+          !isRootLocale(resolvedLocale.localeForFormatting()),
           "The given localeForFormatting cannot be the root.");
 
       Preconditions.checkState(
@@ -284,8 +284,7 @@ public abstract class ResolvedLocale {
       ULocale rootLocaleForFormatting =
           LocalesHierarchyUtils.getHighestAncestorLocale(resolvedLocale.localeForTranslations());
       Preconditions.checkState(
-          LocalesHierarchyUtils.isSameLocale(
-                  resolvedLocale.localeForFormatting(), rootLocaleForFormatting)
+          isSameLocale(resolvedLocale.localeForFormatting(), rootLocaleForFormatting)
               || LocalesHierarchyUtils.isDescendantLocale(
                   resolvedLocale.localeForFormatting(), rootLocaleForFormatting),
           "The given localeForFormatting %s is not the same as, or a descendant of the localeForTranslations %s.",

--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/model/SupportedLocale.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/model/SupportedLocale.java
@@ -20,6 +20,8 @@
 
 package com.spotify.i18n.locales.common.model;
 
+import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isRootLocale;
+
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.ibm.icu.util.ULocale;
@@ -204,7 +206,7 @@ public abstract class SupportedLocale {
       SupportedLocale sl = autoBuild();
 
       Preconditions.checkState(
-          !sl.localeForTranslations().equals(ULocale.ROOT),
+          !isRootLocale(sl.localeForTranslations()),
           "The given localeForTranslations cannot be the root.");
 
       Preconditions.checkState(

--- a/locales-utils/src/main/java/com/spotify/i18n/locales/utils/available/AvailableLocalesUtils.java
+++ b/locales-utils/src/main/java/com/spotify/i18n/locales/utils/available/AvailableLocalesUtils.java
@@ -20,6 +20,7 @@
 
 package com.spotify.i18n.locales.utils.available;
 
+import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isRootLocale;
 import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isSameLocale;
 
 import com.ibm.icu.util.ULocale;
@@ -35,7 +36,7 @@ public class AvailableLocalesUtils {
   // Set containing all CLDR available locales, except the ROOT and en-US-POSIX
   private static final Set<ULocale> CLDR_LOCALES =
       Arrays.stream(ULocale.getAvailableLocales())
-          .filter(l -> !isSameLocale(l, ULocale.ROOT) && !isSameLocale(l, EN_US_POSIX))
+          .filter(l -> !isRootLocale(l) && !isSameLocale(l, EN_US_POSIX))
           .collect(Collectors.toSet());
 
   /**

--- a/locales-utils/src/main/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtils.java
+++ b/locales-utils/src/main/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtils.java
@@ -63,7 +63,7 @@ public class LocalesHierarchyUtils {
    */
   public static Set<ULocale> getDescendantLocales(final ULocale locale) {
     Preconditions.checkNotNull(locale);
-    if (isSameLocale(locale, ULocale.ROOT)) {
+    if (isRootLocale(locale)) {
       // Optimization when requesting descendants of ROOT
       return AvailableLocalesUtils.getCldrLocales();
     } else {
@@ -83,7 +83,7 @@ public class LocalesHierarchyUtils {
    */
   public static List<ULocale> getAncestorLocales(final ULocale locale) {
     Preconditions.checkNotNull(locale);
-    if (isSameLocale(locale, ULocale.ROOT)) {
+    if (isRootLocale(locale)) {
       return List.of();
     }
     List<ULocale> ancestors = new ArrayList<>();
@@ -106,8 +106,7 @@ public class LocalesHierarchyUtils {
    */
   public static ULocale getHighestAncestorLocale(final ULocale locale) {
     Preconditions.checkNotNull(locale);
-    Preconditions.checkArgument(
-        !isSameLocale(locale, ULocale.ROOT), "Param locale cannot be the ROOT.");
+    Preconditions.checkArgument(!isRootLocale(locale), "Param locale cannot be the ROOT.");
     ULocale highestAncestor = locale;
     while (true) {
       Optional<ULocale> currentOpt = getParentLocale(highestAncestor);
@@ -119,6 +118,16 @@ public class LocalesHierarchyUtils {
       }
       highestAncestor = currentOpt.get();
     }
+  }
+
+  /**
+   * Returns true if the given locale is the ROOT locale
+   *
+   * @param underTest the locale under test
+   * @return true if the given locale is the ROOT locale
+   */
+  public static boolean isRootLocale(final ULocale underTest) {
+    return isSameLocale(underTest, ULocale.ROOT);
   }
 
   /**
@@ -193,9 +202,9 @@ public class LocalesHierarchyUtils {
    * @return The parent locale, according to CLDR
    */
   private static Optional<ULocale> getParentLocaleBasedOnFallback(final ULocale locale) {
-    if (isSameLocale(locale, ULocale.ROOT)) {
+    if (isRootLocale(locale)) {
       return Optional.empty();
-    } else if (isSameLocale(locale.getFallback(), ULocale.ROOT)) {
+    } else if (isRootLocale(locale.getFallback())) {
       return Optional.of(ULocale.ROOT);
     } else if (scriptIsMajorLanguageDifferentiator(locale)) {
       // When we know the script is a major differentiator, we assess the parent locale based on it.

--- a/locales-utils/src/test/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtilsTest.java
+++ b/locales-utils/src/test/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtilsTest.java
@@ -242,4 +242,11 @@ class LocalesHierarchyUtilsTest {
 
     assertEquals("Param locale cannot be the ROOT.", thrown.getMessage());
   }
+
+  @Test
+  public void whenTestingForRootLocales_returnsExpected() {
+    assertTrue(LocalesHierarchyUtils.isRootLocale(ULocale.ROOT));
+    assertFalse(LocalesHierarchyUtils.isRootLocale(ULocale.FRANCE));
+    assertFalse(LocalesHierarchyUtils.isRootLocale(ULocale.FRENCH));
+  }
 }


### PR DESCRIPTION
We make use of `isSameLocale` in many places, to validate whether the given locale is the `ROOT` locale. Let's make this more straightforward and introduce a `isRootLocale` method.