### PR TITLE
feat: Add available written/spoken languages, and LanguageUtils

### DIFF
--- a/locales-utils/src/main/java/com/spotify/i18n/locales/utils/available/AvailableLocalesUtils.java
+++ b/locales-utils/src/main/java/com/spotify/i18n/locales/utils/available/AvailableLocalesUtils.java
@@ -20,13 +20,21 @@
 
 package com.spotify.i18n.locales.utils.available;
 
+import static com.ibm.icu.util.ULocale.CHINESE;
+import static com.ibm.icu.util.ULocale.SIMPLIFIED_CHINESE;
+import static com.ibm.icu.util.ULocale.TRADITIONAL_CHINESE;
+import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isLanguageWrittenInSeveralScripts;
 import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isRootLocale;
 import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isSameLocale;
 
 import com.ibm.icu.util.ULocale;
+import com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils;
+import com.spotify.i18n.locales.utils.language.LanguageUtils;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class AvailableLocalesUtils {
 
@@ -37,6 +45,38 @@ public class AvailableLocalesUtils {
   private static final Set<ULocale> CLDR_LOCALES =
       Arrays.stream(ULocale.getAvailableLocales())
           .filter(l -> !isRootLocale(l) && !isSameLocale(l, EN_US_POSIX))
+          .collect(Collectors.toSet());
+
+  // Set containing all written language locales. Languages which can only be written in a single
+  // script are identified using the language code only. The ones that can be written in several
+  // scripts are identified using both the language and script codes.
+  private static final Set<ULocale> WRITTEN_LANGUAGE_LOCALES =
+      CLDR_LOCALES.stream()
+          .filter(LocalesHierarchyUtils::isHighestAncestorLocale)
+          .map(
+              locale ->
+                  Optional.of(locale)
+                      .filter(l -> l.getScript().isEmpty())
+                      .filter(l -> isLanguageWrittenInSeveralScripts(l.getLanguage()))
+                      .map(ULocale::addLikelySubtags)
+                      .map(
+                          l ->
+                              new ULocale.Builder()
+                                  .setLanguage(l.getLanguage())
+                                  .setScript(l.getScript())
+                                  .build())
+                      .orElse(locale))
+          .collect(Collectors.toSet());
+
+  // Set containing all spoken language locales.
+  private static final Set<ULocale> SPOKEN_LANGUAGE_LOCALES =
+      Stream.concat(
+              // Locales consisting only of a language code, except the ones for Chinese.
+              CLDR_LOCALES.stream()
+                  .filter(locale -> locale.getScript().isEmpty() && locale.getCountry().isEmpty())
+                  .filter(locale -> !CHINESE.getLanguage().equals(locale.getLanguage())),
+              // We explicitly add Simplified and Traditional Chinese as zh-Hans and zh-Hant.
+              Stream.of(SIMPLIFIED_CHINESE, TRADITIONAL_CHINESE))
           .collect(Collectors.toSet());
 
   /**
@@ -71,5 +111,47 @@ public class AvailableLocalesUtils {
    */
   public static Set<ULocale> getReferenceLocales() {
     return REFERENCE_LOCALES;
+  }
+
+  /**
+   * Returns a set containing all unambiguous written language locales available in CLDR. They are
+   * unambiguous in the sense that:
+   *
+   * <ul>
+   *   <li>Languages which can be written in several scripts will always be identified by both a
+   *       language code and a script code.
+   *   <li>Languages that can be written in only one script will be identified only by a language
+   *       code.
+   * </ul>
+   *
+   * This set of locales is safe to use for locale resolution. We however recommend making use of
+   * the {@link LanguageUtils#getWrittenLanguageLocale(String)} helper method to retrieve the
+   * written language associated with any given language tag.
+   *
+   * @see <a href="https://cldr.unicode.org/">Unicode CLDR Project</a>
+   */
+  public static Set<ULocale> getWrittenLanguageLocales() {
+    return WRITTEN_LANGUAGE_LOCALES;
+  }
+
+  /**
+   * Returns a set containing all unambiguous spoken language locales available in CLDR. They are
+   * unambiguous in the sense that:
+   *
+   * <ul>
+   *   <li>Languages for which the script is a differentiator will always be identified by both a
+   *       language code and a script code.
+   *   <li>Languages that can only be written in a single script, or that remain the same whether
+   *       written in a given script or another, will be identified only by a language code.
+   * </ul>
+   *
+   * This set of locales is not safe to use for locale resolution. Please make use of the {@link
+   * LanguageUtils#getSpokenLanguageLocale(String)} helper method to retrieve the spoken language
+   * associated with any given language tag.
+   *
+   * @see <a href="https://cldr.unicode.org/">Unicode CLDR Project</a>
+   */
+  public static Set<ULocale> getSpokenLanguageLocales() {
+    return SPOKEN_LANGUAGE_LOCALES;
   }
 }

--- a/locales-utils/src/main/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtils.java
+++ b/locales-utils/src/main/java/com/spotify/i18n/locales/utils/hierarchy/LocalesHierarchyUtils.java
@@ -144,8 +144,8 @@ public class LocalesHierarchyUtils {
   }
 
   /**
-   * Returns true if a given locale is the descendant (direct of subsequent) of the other one,
-   * according to the CLDR hierarchy
+   * Returns true if the locale under test is the descendant (direct of subsequent) of the given
+   * ancestor locale, according to the CLDR hierarchy
    *
    * @param underTest the locale under test
    * @param ancestorLocale the locale supposed to be one of the ancestors of underTest
@@ -173,6 +173,51 @@ public class LocalesHierarchyUtils {
       }
       currentOpt = getParentLocale(currentOpt.get());
     }
+  }
+
+  /**
+   * Returns true if the locale under test is the direct child of the given parent locale, according
+   * to the CLDR hierarchy
+   *
+   * @param underTest the locale under test
+   * @param parentLocale the locale supposed to be one of the ancestors of underTest
+   * @return true if underTest is a direct child of the parentLocale.
+   */
+  public static boolean isChildLocale(final ULocale underTest, final ULocale parentLocale) {
+    Preconditions.checkNotNull(underTest);
+    Preconditions.checkNotNull(parentLocale);
+
+    // Both locales are the same
+    if (isSameLocale(underTest, parentLocale)) {
+      return false;
+    }
+
+    Optional<ULocale> parentOpt = getParentLocale(underTest);
+    return parentOpt.isPresent() && isSameLocale(parentOpt.get(), parentLocale);
+  }
+
+  /**
+   * Returns true if the locale under test is a direct child of the ROOT locale, according to the
+   * CLDR hierarchy
+   *
+   * @param underTest the locale under test
+   * @return true if underTest is a direct child of the ROOT locale.
+   */
+  public static boolean isHighestAncestorLocale(final ULocale underTest) {
+    Preconditions.checkNotNull(underTest);
+    return isChildLocale(underTest, ULocale.ROOT);
+  }
+
+  /**
+   * Returns true for the given language code identifying a language that can be written using
+   * different scripts.
+   *
+   * @param languageCode the language code
+   * @return true if language can be written using different scripts.
+   */
+  public static boolean isLanguageWrittenInSeveralScripts(final String languageCode) {
+    Preconditions.checkNotNull(languageCode);
+    return LANGUAGE_CODES_WITH_MULTIPLE_SCRIPTS_IN_CLDR.contains(languageCode);
   }
 
   /**
@@ -206,7 +251,7 @@ public class LocalesHierarchyUtils {
       return Optional.empty();
     } else if (isRootLocale(locale.getFallback())) {
       return Optional.of(ULocale.ROOT);
-    } else if (scriptIsMajorLanguageDifferentiator(locale)) {
+    } else if (isLanguageWrittenInSeveralScripts(locale.getLanguage())) {
       // When we know the script is a major differentiator, we assess the parent locale based on it.
       return getParentLocaleBasedOnLocaleAndScript(locale);
     } else {
@@ -220,17 +265,6 @@ public class LocalesHierarchyUtils {
         return getParentLocaleBasedOnLocaleAndScript(locale);
       }
     }
-  }
-
-  /**
-   * Returns a flag indicating whether the given locale identifies a language for which the script
-   * can be a language differentiator.
-   *
-   * @param locale any locale
-   * @return boolean value
-   */
-  private static boolean scriptIsMajorLanguageDifferentiator(final ULocale locale) {
-    return LANGUAGE_CODES_WITH_MULTIPLE_SCRIPTS_IN_CLDR.contains(locale.getLanguage());
   }
 
   /**

--- a/locales-utils/src/main/java/com/spotify/i18n/locales/utils/language/LanguageUtils.java
+++ b/locales-utils/src/main/java/com/spotify/i18n/locales/utils/language/LanguageUtils.java
@@ -21,18 +21,12 @@
 package com.spotify.i18n.locales.utils.language;
 
 import static com.ibm.icu.util.ULocale.CHINESE;
-import static com.ibm.icu.util.ULocale.SIMPLIFIED_CHINESE;
-import static com.ibm.icu.util.ULocale.TRADITIONAL_CHINESE;
-import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.getHighestAncestorLocale;
-import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isRootLocale;
-import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isSameLocale;
 
-import com.google.common.base.Preconditions;
+import com.ibm.icu.util.LocaleMatcher;
 import com.ibm.icu.util.ULocale;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+import com.spotify.i18n.locales.utils.available.AvailableLocalesUtils;
+import com.spotify.i18n.locales.utils.languagetag.LanguageTagUtils;
+import java.util.Optional;
 
 /**
  * A Utility class that provides helpers around the concepts of written and spoken languages. It
@@ -44,104 +38,54 @@ import java.util.stream.Collectors;
  */
 public class LanguageUtils {
 
-  /**
-   * Map containing locales identifying languages for which multiple scripts are supported in CLDR,
-   * with their most likely equivalent in terms of language+script (no region code). We consider
-   * them as ambiguous, as the language code only doesn't provide enough information to fully
-   * identify the written language without looking into CLDR data.
-   */
-  private static final Map<ULocale, ULocale> AMBIGUOUS_LANGUAGE_TO_LIKELY_WRITTEN_LANGUAGE_MAP =
-      Arrays.stream(ULocale.getAvailableLocales())
-          .filter(locale -> hasScript(locale))
-          .map(ULocale::getLanguage)
-          .distinct()
-          .collect(
-              Collectors.toMap(
-                  languageCode -> new ULocale.Builder().setLanguage(languageCode).build(),
-                  languageCode ->
-                      new ULocale.Builder()
-                          .setLocale(ULocale.addLikelySubtags(ULocale.forLanguageTag(languageCode)))
-                          .setRegion("")
-                          .build()));
+  // Locale matcher for all written language locales
+  private static final LocaleMatcher WRITTEN_LANGUAGE_LOCALE_MATCHER =
+      LocaleMatcher.builder()
+          .setSupportedULocales(AvailableLocalesUtils.getWrittenLanguageLocales())
+          .setNoDefaultLocale()
+          .build();
 
   /**
-   * Set containing the codes for languages which can only be written in a single script, and are
-   * therefore considered as unambiguous.
-   */
-  private static final Set<String> UNAMBIGUOUS_WRITTEN_LANGUAGE_CODES =
-      Arrays.stream(ULocale.getAvailableLocales())
-          .filter(locale -> locale.getScript().isEmpty() && locale.getCountry().isEmpty())
-          .filter(locale -> !AMBIGUOUS_LANGUAGE_TO_LIKELY_WRITTEN_LANGUAGE_MAP.containsKey(locale))
-          .map(ULocale::getLanguage)
-          .collect(Collectors.toSet());
-
-  /**
-   * Returns the {@link ULocale} identifying the written language associated with the given locale.
-   * The returned locale will consist of a language code at the minimum, but will also contain a
-   * script code for languages that can be written in several scripts.
+   * Returns the optional {@link ULocale} identifying the written language associated with the given
+   * language tag. The returned locale will consist of a language code at the minimum, but will
+   * contain a script code for languages that can be written in several scripts, to alleviate any
+   * possible ambiguity.
    *
-   * @param locale the locale
-   * @return locale identifying the written language
-   * @throws IllegalArgumentException when given locale is the ROOT
+   * @param languageTag the languageTag
+   * @return the optional locale identifying the written language
    */
-  public static ULocale getWrittenLanguageLocale(final ULocale locale) {
-    Preconditions.checkNotNull(locale);
-    Preconditions.checkArgument(!isRootLocale(locale), "Param locale cannot be the ROOT.");
-
-    if (UNAMBIGUOUS_WRITTEN_LANGUAGE_CODES.contains(locale.getLanguage())) {
-      // The language code is enough to identify the written language fully.
-      return new ULocale.Builder().setLanguage(locale.getLanguage()).build();
-    } else {
-      final ULocale highestAncestorLocale = getHighestAncestorLocale(locale);
-      if (hasScript(highestAncestorLocale)) {
-        // When the highest ancestor locale already has a script, we know it is the best possible
-        // identifier for the corresponding written language.
-        return highestAncestorLocale;
-      } else {
-        // When the highest ancestor locale doesn't have a script code defined, we add one for
-        // languages for which we need the differentiation to be explicit. Ex: for Serbian, we will
-        // return sr-Cyrl and not sr, as the language can also be written in sr-Latn. For French, we
-        // will return fr as the language is never written in another script.
-        return AMBIGUOUS_LANGUAGE_TO_LIKELY_WRITTEN_LANGUAGE_MAP.getOrDefault(
-            highestAncestorLocale, highestAncestorLocale);
-      }
-    }
+  public static Optional<ULocale> getWrittenLanguageLocale(final String languageTag) {
+    return LanguageTagUtils.parse(languageTag).map(WRITTEN_LANGUAGE_LOCALE_MATCHER::getBestMatch);
   }
 
   /**
-   * Returns the {@link ULocale} identifying the spoken language associated with the given locale.
-   * The returned locale will consist of a language code only, except for Chinese (Simplified),
-   * which will be identified as zh-Hans, and Chinese (Traditional) which will be identified as
-   * zh-Hant.
+   * Returns the optional {@link ULocale} identifying the spoken language associated with the given
+   * language tag. The returned locale will consist of a language code at the minimum, but will
+   * contain a script code for languages for which the script is a language differentiator, to
+   * alleviate any possible ambiguity. (ex: zh-Hans for Simplified Chinese, and zh-Hant for
+   * Traditional Chinese).
    *
-   * @param locale the locale
-   * @return locale identifying the spoken language
-   * @throws IllegalArgumentException when given locale is the ROOT
+   * @param languageTag the languageTag
+   * @return the optional locale identifying the written language
    */
-  public static ULocale getSpokenLanguageLocale(final ULocale locale) {
-    Preconditions.checkNotNull(locale);
-    Preconditions.checkArgument(!isRootLocale(locale), "Param locale cannot be the ROOT.");
-
-    if (CHINESE.getLanguage().equals(locale.getLanguage())) {
-      // Chinese is the only language for which the script is a language differentiator.
-      if (isSameLocale(getHighestAncestorLocale(locale), TRADITIONAL_CHINESE)) {
-        return TRADITIONAL_CHINESE;
-      } else {
-        return SIMPLIFIED_CHINESE;
-      }
-    } else {
-      // All other spoken languages only require the language code to be defined.
-      return new ULocale.Builder().setLanguage(locale.getLanguage()).build();
-    }
+  public static Optional<ULocale> getSpokenLanguageLocale(final String languageTag) {
+    return LanguageTagUtils.parse(languageTag)
+        .map(WRITTEN_LANGUAGE_LOCALE_MATCHER::getBestMatch)
+        .map(LanguageUtils::getCorrespondingSpokenLanguageLocale);
   }
 
   /**
-   * Returns true if the given locale has a script code defined.
+   * Returns the given written language locale stripped of its script code (if present), except for
+   * the Chinese language, for which we need to retain it.
    *
-   * @param locale the locale under test
-   * @return true if the given locale has a script code defined
+   * @param locale written language locale
+   * @return actual spoken language locale
    */
-  private static boolean hasScript(final ULocale locale) {
-    return !locale.getScript().isEmpty();
+  private static ULocale getCorrespondingSpokenLanguageLocale(final ULocale locale) {
+    if (locale.getScript().isEmpty() || CHINESE.getLanguage().equals(locale.getLanguage())) {
+      return locale;
+    } else {
+      return locale.getFallback();
+    }
   }
 }

--- a/locales-utils/src/test/java/com/spotify/i18n/locales/utils/available/AvailableLocalesUtilsTest.java
+++ b/locales-utils/src/test/java/com/spotify/i18n/locales/utils/available/AvailableLocalesUtilsTest.java
@@ -20,11 +20,17 @@
 
 package com.spotify.i18n.locales.utils.available;
 
+import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isLanguageWrittenInSeveralScripts;
+import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isRootLocale;
 import static com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils.isSameLocale;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.ibm.icu.util.ULocale;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class AvailableLocalesUtilsTest {
 
@@ -56,5 +62,37 @@ class AvailableLocalesUtilsTest {
     for (ULocale referenceLocale : AvailableLocalesUtils.getReferenceLocales()) {
       assertTrue(isSameLocale(ULocale.minimizeSubtags(referenceLocale), referenceLocale));
     }
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void writtenLanguageLocaleIsUnambiguous(final ULocale locale) {
+    assertFalse(isRootLocale(locale));
+    assertTrue(locale.getCountry().isEmpty());
+    if (isLanguageWrittenInSeveralScripts(locale.getLanguage())) {
+      assertFalse(locale.getScript().isEmpty());
+    } else {
+      assertTrue(locale.getScript().isEmpty());
+    }
+  }
+
+  public static Stream<Arguments> writtenLanguageLocaleIsUnambiguous() {
+    return AvailableLocalesUtils.getWrittenLanguageLocales().stream().map(Arguments::of);
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void spokenLanguageLocaleIsUnambiguous(final ULocale locale) {
+    assertFalse(isRootLocale(locale));
+    assertTrue(locale.getCountry().isEmpty());
+    if (ULocale.CHINESE.getLanguage().equals(locale.getLanguage())) {
+      assertFalse(locale.getScript().isEmpty());
+    } else {
+      assertTrue(locale.getScript().isEmpty());
+    }
+  }
+
+  public static Stream<Arguments> spokenLanguageLocaleIsUnambiguous() {
+    return AvailableLocalesUtils.getSpokenLanguageLocales().stream().map(Arguments::of);
   }
 }

--- a/locales-utils/src/test/java/com/spotify/i18n/locales/utils/language/LanguageUtilsTest.java
+++ b/locales-utils/src/test/java/com/spotify/i18n/locales/utils/language/LanguageUtilsTest.java
@@ -32,6 +32,7 @@ import com.ibm.icu.util.ULocale;
 import com.spotify.i18n.locales.utils.available.AvailableLocalesUtils;
 import com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -45,11 +46,12 @@ class LanguageUtilsTest {
   @ParameterizedTest
   @MethodSource("cldrAvailableLocales")
   void canGetWrittenLanguageLocaleForCldrAvailableLocales(final ULocale locale) {
-    final ULocale writtenLanguageLocale = LanguageUtils.getWrittenLanguageLocale(locale);
-    assertNotNull(writtenLanguageLocale);
-    assertFalse(isRootLocale(writtenLanguageLocale));
-    assertTrue(writtenLanguageLocale.getCountry().isEmpty());
-    switch (writtenLanguageLocale.getLanguage()) {
+    final Optional<ULocale> writtenLanguageLocale =
+        LanguageUtils.getWrittenLanguageLocale(locale.toLanguageTag());
+    assertFalse(writtenLanguageLocale.isEmpty());
+    assertFalse(isRootLocale(writtenLanguageLocale.get()));
+    assertTrue(writtenLanguageLocale.get().getCountry().isEmpty());
+    switch (writtenLanguageLocale.get().getLanguage()) {
       case "az":
       case "bs":
       case "ff":
@@ -69,10 +71,10 @@ class LanguageUtilsTest {
       case "vai":
       case "yue":
       case "zh":
-        assertFalse(writtenLanguageLocale.getScript().isEmpty());
+        assertFalse(writtenLanguageLocale.get().getScript().isEmpty());
         break;
       default:
-        assertTrue(writtenLanguageLocale.getScript().isEmpty());
+        assertTrue(writtenLanguageLocale.get().getScript().isEmpty());
         break;
     }
   }
@@ -80,18 +82,19 @@ class LanguageUtilsTest {
   @ParameterizedTest
   @MethodSource("cldrAvailableLocales")
   void canGetSpokenLanguageLocaleForCldrAvailableLocales(final ULocale locale) {
-    final ULocale spokenLanguageLocale = LanguageUtils.getSpokenLanguageLocale(locale);
-    assertNotNull(spokenLanguageLocale);
-    assertFalse(isRootLocale(spokenLanguageLocale));
-    assertTrue(spokenLanguageLocale.getCountry().isEmpty());
+    final Optional<ULocale> spokenLanguageLocale =
+        LanguageUtils.getSpokenLanguageLocale(locale.toLanguageTag());
+    assertFalse(spokenLanguageLocale.isEmpty());
+    assertFalse(isRootLocale(spokenLanguageLocale.get()));
+    assertTrue(spokenLanguageLocale.get().getCountry().isEmpty());
 
     if (isSameLocale(locale, CHINESE) || isDescendantLocale(locale, CHINESE)) {
-      isSameLocale(spokenLanguageLocale, SIMPLIFIED_CHINESE);
+      isSameLocale(spokenLanguageLocale.get(), SIMPLIFIED_CHINESE);
     } else if (isSameLocale(locale, TRADITIONAL_CHINESE)
         || isDescendantLocale(locale, TRADITIONAL_CHINESE)) {
-      isSameLocale(spokenLanguageLocale, TRADITIONAL_CHINESE);
+      isSameLocale(spokenLanguageLocale.get(), TRADITIONAL_CHINESE);
     } else {
-      assertTrue(spokenLanguageLocale.getScript().isEmpty());
+      assertTrue(spokenLanguageLocale.get().getScript().isEmpty());
     }
   }
 


### PR DESCRIPTION
We need to be able to reason around the concept of written language or spoken language.

The `AvailableLocalesUtils` class now exposes the following 2 new methods:

```java
public static Set<ULocale> getWrittenLanguageLocales();
public static Set<ULocale> getSpokenLanguageLocales();
```

In order to facilitate the navigation in the CLDR tree structure, we added the following helper methods to the `LocalesHierarchyUtils` class:
```java
  public static boolean isChildLocale(final ULocale underTest, final ULocale parentLocale);
  public static boolean isHighestAncestorLocale(final ULocale underTest);
  public static boolean isLanguageWrittenInSeveralScripts(final String languageCode);
```

The new `LanguageUtils` class (name pending validation) offers 2 helper methods:

```java
  public static Optional<ULocale> getWrittenLanguageLocale(final String languageTag);
  public static Optional<ULocale> getSpokenLanguageLocale(final String languageTag);
```

We made an arbitrary decision to force the presence of a script code for languages that can be written in several scripts, to alleviate any potential ambiguity. 

For examples:
- Getting the written language locale for Serbian `sr` using `getWrittenLanguageLocale("sr");` will return the `sr-Cyrl` locale, because Serbian can also be written using Cyrillic script.
- Getting the written language locale for French `fr` using `getWrittenLanguageLocale("fr");` will return the `fr` locale, because French can only be written in a single script (Latin).

Aside from Chinese, all spoken languages require only a language code to be unequivocally identified (confirmed after manual investigation, links enclosed in one of the unit tests). We therefore made the decision to force the script only for the `zh` locales, which are therefore present as `zh-Hans` (Simplified Chinese) and `zh-Hant` (Traditional Chinese).

For examples:
- Getting the spoken language locale for Chinese `zh` using `getSpokenLanguageLocale("zh");` (or `zh-CN` for that matter) will return the `zh-Hans` locale, because `zh` is an alias of `zh-Hans`.
- Getting the spoken language locale for Chinese (Hong-Kong) `zh-HK` using `getSpokenLanguageLocale("zh-HK");` will return the `zh-Hant` locale, because the likely script for that region is Traditional.