### PR TITLE
chore: Improve locale affinity logic with LanguageUtils

### DIFF
--- a/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/ReferenceLocalesCalculatorBaseImplTest.java
+++ b/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/ReferenceLocalesCalculatorBaseImplTest.java
@@ -34,6 +34,7 @@ import com.spotify.i18n.locales.common.ReferenceLocalesCalculator;
 import com.spotify.i18n.locales.common.model.LocaleAffinity;
 import com.spotify.i18n.locales.common.model.RelatedReferenceLocale;
 import com.spotify.i18n.locales.utils.available.AvailableLocalesUtils;
+import com.spotify.i18n.locales.utils.language.LanguageUtils;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -69,7 +70,8 @@ class ReferenceLocalesCalculatorBaseImplTest {
 
       ULocale referenceLanguageScriptOnly = getLocaleWithLanguageAndScriptOnly(referenceLocale);
 
-      if (isSameLocale(inputLanguageScriptOnly, referenceLanguageScriptOnly)) {
+      if (isSameLocale(inputLanguageScriptOnly, referenceLanguageScriptOnly)
+          || isSameSpokenLanguage(inputLanguageScriptOnly, referenceLanguageScriptOnly)) {
         assertEquals(
             SAME_OR_INTERCHANGEABLE,
             affinity,
@@ -101,6 +103,12 @@ class ReferenceLocalesCalculatorBaseImplTest {
     }
   }
 
+  private boolean isSameSpokenLanguage(
+      ULocale inputLanguageScriptOnly, ULocale referenceLanguageScriptOnly) {
+    return LanguageUtils.getSpokenLanguageLocale(inputLanguageScriptOnly.toLanguageTag())
+        .equals(LanguageUtils.getSpokenLanguageLocale(referenceLanguageScriptOnly.toLanguageTag()));
+  }
+
   private static ULocale getLocaleWithLanguageAndScriptOnly(ULocale input) {
     return new Builder()
         .setLocale(ULocale.addLikelySubtags(input))
@@ -117,9 +125,12 @@ class ReferenceLocalesCalculatorBaseImplTest {
         // Bosnian and Croatian
       case "bs-Latn":
         return reference.equals("hr-Latn");
+        // Bosnian and Croatian
+      case "bs-Cyrl":
+        return reference.equals("hr-Latn");
         // Croatian and Bosnian
       case "hr-Latn":
-        return reference.equals("bs-Latn");
+        return reference.equals("bs-Latn") || reference.equals("bs-Cyrl");
         // German and Luxembourgish or Swiss German
       case "de-Latn":
         return reference.equals("lb-Latn") || reference.equals("gsw-Latn");
@@ -469,7 +480,7 @@ class ReferenceLocalesCalculatorBaseImplTest {
         // Norwegian
         rrl("no", SAME_OR_INTERCHANGEABLE),
         // Nynorsk
-        rrl("nn", LOW));
+        rrl("nn", SAME_OR_INTERCHANGEABLE));
   }
 
   private static List<RelatedReferenceLocale> serbian() {


### PR DESCRIPTION
We can improve and optimize the locale affinity logic by making use of the newly introduced `LanguageUtils` class.

Instead of relying on a score-based affinity only, we first calculate a "same language" affinity by testing for corresponding spoken language.

This actually has improved the results for several locales:
- Locales for which the language code is sufficient to identity a language are now matched with an affinity `SAME_OR_INTERCHANGEABLE`. The score based implementation enforces script matching, which was not a good fit for the affinity logic. For instance: `hr` (Croatian) and `bs` (Bosnian) are now matched with each other with an affinity `SAME_OR_INTERCHANGEABLE`, whether Bosnian is written in Latin or Cyrillic script, which is a more accurate outcome.
- `nn` (Norwegian Nynorsk) is now matched with `nb` (Norwegian Bokmål) with an affinity `SAME_OR_INTERCHANGEABLE` instead of `LOW` which is a more accurate outcome. 

It is also a nice logic optimization, as we won't systematically be calculating maximized locales (which is a costly operation).