### PR TITLE
chore: Update foss-root to version 18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>foss-root</artifactId>
-    <version>17</version>
+    <version>18</version>
   </parent>
 
   <groupId>com.spotify.i18n</groupId>


### PR DESCRIPTION
We can't release using the current `foss-root` pom parent version 17, because `ossrh` service was deprecated.

We need to update to version 18, which includes the following changes:
- https://github.com/spotify/foss-root/pull/29
- https://github.com/spotify/foss-root/pull/30