### PR TITLE
feat: Add minimum affinity option to locales resolver

### DIFF
--- a/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/LocalesResolverBaseImpl.java
+++ b/locales-common/src/main/java/com/spotify/i18n/locales/common/impl/LocalesResolverBaseImpl.java
@@ -20,11 +20,18 @@
 
 package com.spotify.i18n.locales.common.impl;
 
+import static com.spotify.i18n.locales.common.model.LocaleAffinity.HIGH;
+import static com.spotify.i18n.locales.common.model.LocaleAffinity.LOW;
+import static com.spotify.i18n.locales.common.model.LocaleAffinity.MUTUALLY_INTELLIGIBLE;
+import static com.spotify.i18n.locales.common.model.LocaleAffinity.SAME;
+
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.ibm.icu.util.LocaleMatcher;
 import com.ibm.icu.util.ULocale;
 import com.spotify.i18n.locales.common.LocalesResolver;
+import com.spotify.i18n.locales.common.model.LocaleAffinity;
 import com.spotify.i18n.locales.common.model.ResolvedLocale;
 import com.spotify.i18n.locales.common.model.SupportedLocale;
 import com.spotify.i18n.locales.utils.acceptlanguage.AcceptLanguageUtils;
@@ -32,6 +39,7 @@ import com.spotify.i18n.locales.utils.available.AvailableLocalesUtils;
 import com.spotify.i18n.locales.utils.hierarchy.LocalesHierarchyUtils;
 import com.spotify.i18n.locales.utils.languagetag.LanguageTagUtils;
 import java.util.List;
+import java.util.Locale;
 import java.util.Locale.LanguageRange;
 import java.util.Map;
 import java.util.Optional;
@@ -68,6 +76,9 @@ public abstract class LocalesResolverBaseImpl implements LocalesResolver {
           .map(ULocale::getLanguage)
           .collect(Collectors.toSet());
 
+  /** Default required locale affinity for resolved locale */
+  public static final LocaleAffinity DEFAULT_REQUIRED_LOCALE_AFFINITY = MUTUALLY_INTELLIGIBLE;
+
   /** Wildcard character for language ranges */
   private static final String LANGUAGE_RANGE_WILDCARD = "*";
 
@@ -75,11 +86,28 @@ public abstract class LocalesResolverBaseImpl implements LocalesResolver {
   private static final String ULOCALE_UNDEFINED_CODE = "Und";
 
   /**
+   * Affinity to distance threshold for {@link LocaleMatcher.Builder#setMaxDistance(Locale, Locale)}
+   */
+  private static final Map<LocaleAffinity, Integer> AFFINITY_TO_DISTANCE_THRESHOLD =
+      Map.of(
+          SAME, 6,
+          MUTUALLY_INTELLIGIBLE, 10,
+          HIGH, 20,
+          LOW, 100);
+
+  /**
    * Returns the set of {@link SupportedLocale} against which locale resolution will be performed.
    *
    * @return The set of {@link SupportedLocale}s
    */
   public abstract Set<SupportedLocale> supportedLocales();
+
+  /**
+   * Returns the required {@link LocaleAffinity} for the resolved locale
+   *
+   * @return The required {@link LocaleAffinity}
+   */
+  public abstract LocaleAffinity requiredLocaleAffinity();
 
   /**
    * Returns the default {@link ResolvedLocale} that will be used as final fallback for a given
@@ -442,6 +470,7 @@ public abstract class LocalesResolverBaseImpl implements LocalesResolver {
   private LocaleMatcher getLocaleMatcher(final Set<ULocale> supportedLocales) {
     return LocaleMatcher.builder()
         .setSupportedULocales(supportedLocales)
+        .internalSetThresholdDistance(AFFINITY_TO_DISTANCE_THRESHOLD.get(requiredLocaleAffinity()))
         .setNoDefaultLocale()
         .build();
   }
@@ -459,7 +488,9 @@ public abstract class LocalesResolverBaseImpl implements LocalesResolver {
   /** A builder for a {@link LocalesResolverBaseImpl}. */
   @AutoValue.Builder
   public abstract static class Builder {
-    Builder() {} // package private constructor
+    Builder() { // package private constructor
+      requiredLocaleAffinity(DEFAULT_REQUIRED_LOCALE_AFFINITY);
+    }
 
     /**
      * Configures the default {@link ResolvedLocale} that will be returned if locale resolution
@@ -479,11 +510,24 @@ public abstract class LocalesResolverBaseImpl implements LocalesResolver {
      */
     public abstract Builder supportedLocales(final Set<SupportedLocale> supportedLocales);
 
+    /**
+     * Configures the set of {@link LocaleAffinity} based on which locale resolution will be
+     * performed.
+     *
+     * @param requiredLocaleAffinity
+     * @return The {@link Builder}
+     */
+    public abstract Builder requiredLocaleAffinity(final LocaleAffinity requiredLocaleAffinity);
+
     abstract LocalesResolverBaseImpl autoBuild();
 
     /** Builds a {@link LocalesResolver} out of this builder. */
     public final LocalesResolver build() {
-      return autoBuild();
+      LocalesResolverBaseImpl built = autoBuild();
+      Preconditions.checkState(
+          built.requiredLocaleAffinity() != LocaleAffinity.NONE,
+          "Required locale affinity for resolved locale cannot be NONE.");
+      return built;
     }
   }
 }

--- a/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocaleAffinityBiCalculatorBaseImplTest.java
+++ b/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocaleAffinityBiCalculatorBaseImplTest.java
@@ -146,7 +146,10 @@ class LocaleAffinityBiCalculatorBaseImplTest {
         Arguments.of("zh-Hant", "zh", NONE),
         Arguments.of("zh-MK", "zh-CN", SAME),
         Arguments.of("zh-FR", "zh-CN", SAME),
-        Arguments.of("zh-TW", "zh-US", SAME));
+        Arguments.of("zh-TW", "zh-US", SAME),
+
+        // Malay
+        Arguments.of("ms", "id", HIGH));
   }
 
   @Test

--- a/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocaleAffinityCalculatorBaseImplTest.java
+++ b/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocaleAffinityCalculatorBaseImplTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.i18n.locales.common.impl;
 
+import static com.spotify.i18n.locales.common.model.LocaleAffinity.HIGH;
 import static com.spotify.i18n.locales.common.model.LocaleAffinity.LOW;
 import static com.spotify.i18n.locales.common.model.LocaleAffinity.MUTUALLY_INTELLIGIBLE;
 import static com.spotify.i18n.locales.common.model.LocaleAffinity.NONE;
@@ -50,7 +51,10 @@ class LocaleAffinityCalculatorBaseImplTest {
   public static final LocaleAffinityCalculator CALCULATOR_AGAINST_TEST_SET_OF_LOCALES =
       LocaleAffinityCalculatorBaseImpl.builder()
           .againstLocales(
-              Set.of("ar", "bs-Cyrl", "es", "fr", "ja", "pt", "sr-Latn", "zh-Hant").stream()
+              Set.of(
+                      "ar", "bs-Cyrl", "es", "fr", "id", "ja", "nb", "pt", "ru", "sr-Latn",
+                      "zh-Hant")
+                  .stream()
                   .map(ULocale::forLanguageTag)
                   .collect(Collectors.toSet()))
           .build();
@@ -186,6 +190,9 @@ class LocaleAffinityCalculatorBaseImplTest {
         // Basque should be matched, since we support Spanish
         Arguments.of("eu", LOW),
 
+        // Danish
+        Arguments.of("da", HIGH),
+
         // French
         Arguments.of("fr", SAME),
         Arguments.of("fr-BE", SAME),
@@ -205,6 +212,17 @@ class LocaleAffinityCalculatorBaseImplTest {
         Arguments.of("sr", SAME),
         Arguments.of("sr-Latn", SAME),
         Arguments.of("sr-Cyrl-ME", SAME),
+
+        // Kazakh should be matched with Russian
+        Arguments.of("kk", NONE),
+        Arguments.of("kk-KZ", NONE),
+
+        // Malay
+        Arguments.of("ms", HIGH),
+
+        // Mongolian should be matched with Russian
+        Arguments.of("mn", NONE),
+        Arguments.of("mn-MN", NONE),
 
         // Portuguese
         Arguments.of("pt", SAME),

--- a/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocalesResolverBaseImplTest.java
+++ b/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocalesResolverBaseImplTest.java
@@ -23,6 +23,7 @@ package com.spotify.i18n.locales.common.impl;
 import static com.spotify.i18n.locales.common.model.LocaleAffinity.HIGH;
 import static com.spotify.i18n.locales.common.model.LocaleAffinity.LOW;
 import static com.spotify.i18n.locales.common.model.LocaleAffinity.MUTUALLY_INTELLIGIBLE;
+import static com.spotify.i18n.locales.common.model.LocaleAffinity.NONE;
 import static com.spotify.i18n.locales.common.model.LocaleAffinity.SAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -58,6 +59,23 @@ class LocalesResolverBaseImplTest {
 
     assertEquals(
         thrown.getMessage(), "Missing required properties: supportedLocales defaultResolvedLocale");
+  }
+
+
+  @Test
+  void whenBuildingWithRequiredLocaleAffinityNONE_buildFails() {
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> LocalesResolverBaseImpl.builder()
+            .supportedLocales(
+                Set.of("fr", "ar", "zh-Hant", "ja").stream()
+                    .map(SupportedLocale::fromLanguageTag)
+                    .collect(Collectors.toSet()))
+            .defaultResolvedLocale(DEFAULT_LOCALE)
+            .requiredLocaleAffinity(NONE)
+            .build());
+
+    assertEquals(
+        thrown.getMessage(), "Required locale affinity for resolved locale cannot be NONE.");
   }
 
   @Test

--- a/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocalesResolverBaseImplTest.java
+++ b/locales-common/src/test/java/com/spotify/i18n/locales/common/impl/LocalesResolverBaseImplTest.java
@@ -20,12 +20,20 @@
 
 package com.spotify.i18n.locales.common.impl;
 
+import static com.spotify.i18n.locales.common.model.LocaleAffinity.HIGH;
+import static com.spotify.i18n.locales.common.model.LocaleAffinity.LOW;
+import static com.spotify.i18n.locales.common.model.LocaleAffinity.MUTUALLY_INTELLIGIBLE;
+import static com.spotify.i18n.locales.common.model.LocaleAffinity.SAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.ibm.icu.impl.locale.LocaleDistance;
+import com.ibm.icu.util.LocaleMatcher.FavorSubtag;
+import com.ibm.icu.util.ULocale;
 import com.spotify.i18n.locales.common.LocalesResolver;
+import com.spotify.i18n.locales.common.model.LocaleAffinity;
 import com.spotify.i18n.locales.common.model.ResolvedLocale;
 import com.spotify.i18n.locales.common.model.SupportedLocale;
 import java.util.Collections;
@@ -33,6 +41,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -173,7 +182,7 @@ class LocalesResolverBaseImplTest {
   static Stream<Arguments> whenResolvingUnsupportedLocale_returnBetterDefaultLocale() {
     Set<SupportedLocale> supportedLocales =
         // We add 3 different variants of English to the list of supported locales
-        Set.of("en", "en-GB", "en-IN", "hi", "fr", "ar", "zh-Hant", "ja").stream()
+        Set.of("ar", "en", "en-GB", "en-IN", "fr", "hi", "hr", "id", "ja", "nb", "zh-Hant").stream()
             .map(SupportedLocale::fromLanguageTag)
             .collect(Collectors.toSet());
 
@@ -199,7 +208,10 @@ class LocalesResolverBaseImplTest {
             supportedLocales,
             ResolvedLocale.fromLanguageTags("en-IN", List.of("en"), "en-IN")),
         // Tamil (Malaysia)
-        Arguments.of("ta-MY", supportedLocales, ResolvedLocale.fromLanguageTags("en", "en-MY")),
+        Arguments.of(
+            "ta-MY",
+            supportedLocales,
+            ResolvedLocale.fromLanguageTags("en-GB", List.of("en"), "en-MY")),
         // Nama (Namibia)
         Arguments.of(
             "naq-NA",
@@ -209,7 +221,19 @@ class LocalesResolverBaseImplTest {
         Arguments.of(
             "dz-BT",
             supportedLocales,
-            ResolvedLocale.fromLanguageTags("en-GB", List.of("en"), "en-GB")));
+            ResolvedLocale.fromLanguageTags("en-GB", List.of("en"), "en-GB")),
+        // Bosnian (Bosnia)
+        Arguments.of("bs-BA", supportedLocales, ResolvedLocale.fromLanguageTags("hr", "hr-BA")),
+        // Danish (Danemark), should NOT be matched with nb (Norwegian Bokmål)
+        Arguments.of(
+            "da-DK",
+            supportedLocales,
+            ResolvedLocale.fromLanguageTags("en-GB", List.of("en"), "en-DK")),
+        // Malay (Malaysia), should NOT be matched with id (Indonesian)
+        Arguments.of(
+            "ms-MY",
+            supportedLocales,
+            ResolvedLocale.fromLanguageTags("en-GB", List.of("en"), "en-MY")));
   }
 
   private static final Set<SupportedLocale> SUPPORTED_LOCALES =
@@ -304,6 +328,7 @@ class LocalesResolverBaseImplTest {
         LocalesResolverBaseImpl.builder()
             .supportedLocales(SUPPORTED_LOCALES)
             .defaultResolvedLocale(DEFAULT_LOCALE)
+            .requiredLocaleAffinity(MUTUALLY_INTELLIGIBLE)
             .build();
 
     ResolvedLocale expectedResolvedLocale =
@@ -318,13 +343,14 @@ class LocalesResolverBaseImplTest {
     return Stream.of(
         Arguments.of("en-LK", "en-GB", List.of("en"), "en-GB"),
         Arguments.of("es-419", "es-419", List.of("es"), "es-419"),
-        Arguments.of("ga-IE", "en", Collections.emptyList(), "en-IE"),
+        Arguments.of("ga-IE", "en-GB", List.of("en"), "en-IE"),
         Arguments.of("gn-PY", "es-419", List.of("es"), "es-PY"),
-        Arguments.of("kk-KZ", "ru", Collections.emptyList(), "ru-KZ"),
-        Arguments.of("mn-MN", "ru", Collections.emptyList(), "ru-RU"),
-        Arguments.of("nso-ZA", "en", Collections.emptyList(), "en-ZA"),
-        Arguments.of("sq-XK", "en", Collections.emptyList(), "en-US"),
+        Arguments.of("kk-KZ", "en-GB", List.of("en"), "en-GB"),
+        Arguments.of("mn-MN", "en-GB", List.of("en"), "en-GB"),
+        Arguments.of("nso-ZA", "en-GB", List.of("en"), "en-ZA"),
+        Arguments.of("sq-XK", "en-GB", List.of("en"), "en-GB"),
         Arguments.of("sr-Latn-XK", "sr-Latn", Collections.emptyList(), "sr-Latn-XK"),
+        Arguments.of("sr-Cyrl-XK", "sr-Latn", Collections.emptyList(), "sr-Latn-XK"),
         Arguments.of("sr-XK", "sr-Latn", Collections.emptyList(), "sr-Latn-XK"));
   }
 
@@ -348,5 +374,133 @@ class LocalesResolverBaseImplTest {
             List.of("es"),
             "es-419");
     assertThat(resolver.resolve(localeToResolve), is(expectedResolvedLocale));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void givenRequiredLocaleAffinity_whenResolvingLocale_returnsExpected(
+      final LocaleAffinity requiredAffinity, String input, ResolvedLocale resolvedLocale) {
+    final Set<SupportedLocale> supportedLocales =
+        Set.of("es", "es-419", "hr", "nb", "id", "ru", "sr-Latn").stream()
+            .map(SupportedLocale::fromLanguageTag)
+            .collect(Collectors.toSet());
+
+    final LocalesResolver resolver =
+        LocalesResolverBaseImpl.builder()
+            .supportedLocales(supportedLocales)
+            .defaultResolvedLocale(DEFAULT_LOCALE)
+            .requiredLocaleAffinity(requiredAffinity)
+            .build();
+
+    assertEquals(resolvedLocale, resolver.resolve(input));
+  }
+
+  static Stream<Arguments> givenRequiredLocaleAffinity_whenResolvingLocale_returnsExpected() {
+    Set<SupportedLocale> supportedLocales =
+        Set.of("es", "es-419", "hr", "nb", "id", "ru", "sr-Latn").stream()
+            .map(SupportedLocale::fromLanguageTag)
+            .collect(Collectors.toSet());
+
+    return Stream.of(
+        // SAME affinity
+        Arguments.of(SAME, "bs", DEFAULT_LOCALE), // Bosnian should not resolve to Croatian
+        Arguments.of(SAME, "da", DEFAULT_LOCALE), // Danish should not resolve to Norwegian Bokmål
+        Arguments.of(SAME, "ms", DEFAULT_LOCALE), // Malay should not resolve to Indonesian
+        Arguments.of(SAME, "kk", DEFAULT_LOCALE), // Kazakh should not resolve to Russian
+        Arguments.of(SAME, "mn", DEFAULT_LOCALE), // Mongolian should not resolve to Russian
+        Arguments.of(
+            SAME,
+            "es-PY",
+            ResolvedLocale.fromLanguageTags(
+                "es-419", List.of("es"), "es-PY")), // Spanish (Paraguay) should resolve to
+        Arguments.of(
+            SAME,
+            "es-PT",
+            ResolvedLocale.fromLanguageTags("es", "es-ES")), // Spanish (Paraguay) should resolve to
+        Arguments.of(
+            SAME,
+            "sr-Cyrl-RS",
+            ResolvedLocale.fromLanguageTags(
+                "sr-Latn", "sr-Latn")), // Serbian (Cyrillic) should resolve to Serbian (Latin)
+
+        // Mutually Intelligible
+        Arguments.of(MUTUALLY_INTELLIGIBLE, "bs", ResolvedLocale.fromLanguageTags("hr", "hr-BA")),
+        Arguments.of(
+            MUTUALLY_INTELLIGIBLE,
+            "da",
+            DEFAULT_LOCALE), // Danish should not resolve to Norwegian Bokmål
+        Arguments.of(
+            MUTUALLY_INTELLIGIBLE, "ms", DEFAULT_LOCALE), // Malay should not resolve to Indonesian
+        Arguments.of(
+            MUTUALLY_INTELLIGIBLE, "kk", DEFAULT_LOCALE), // Kazakh should not resolve to Russian
+        Arguments.of(
+            MUTUALLY_INTELLIGIBLE, "mn", DEFAULT_LOCALE), // Mongolian should not resolve to Russian
+        Arguments.of(MUTUALLY_INTELLIGIBLE, "eu-ES", DEFAULT_LOCALE),
+        Arguments.of(MUTUALLY_INTELLIGIBLE, "ca-AD", DEFAULT_LOCALE),
+        // Spanish (Paraguay) should resolve to Spanish (Latin America)
+        Arguments.of(
+            MUTUALLY_INTELLIGIBLE,
+            "es-PY",
+            ResolvedLocale.fromLanguageTags("es-419", List.of("es"), "es-PY")),
+        // Spanish (Portugal) should resolve to Spanish
+        Arguments.of(
+            MUTUALLY_INTELLIGIBLE, "es-PT", ResolvedLocale.fromLanguageTags("es", "es-ES")),
+        // Serbian (Cyrillic) should resolve to Serbian (Latin)
+        Arguments.of(
+            MUTUALLY_INTELLIGIBLE,
+            "sr-Cyrl-RS",
+            ResolvedLocale.fromLanguageTags("sr-Latn", "sr-Latn")),
+
+        // HIGH affinity
+        Arguments.of(HIGH, "da", ResolvedLocale.fromLanguageTags("nb", "nb-NO")),
+        Arguments.of(HIGH, "da-DK", ResolvedLocale.fromLanguageTags("nb", "nb-NO")),
+
+        // ⚠️ Logic for Malay differs from LocaleAffinityBiCalculatorBaseImpl, it should resolve to
+        // Indonesian. This should be fixed somehow, but is considered as acceptable for now.
+        Arguments.of(HIGH, "ms", DEFAULT_LOCALE),
+        Arguments.of(HIGH, "ms-MY", DEFAULT_LOCALE),
+        Arguments.of(HIGH, "mn-KZ", DEFAULT_LOCALE),
+        Arguments.of(HIGH, "mn", DEFAULT_LOCALE),
+        Arguments.of(HIGH, "eu-ES", DEFAULT_LOCALE),
+        Arguments.of(HIGH, "ca-AD", DEFAULT_LOCALE),
+
+        // LOW affinity
+        Arguments.of(LOW, "da", ResolvedLocale.fromLanguageTags("nb", "nb-NO")),
+        Arguments.of(LOW, "da-DK", ResolvedLocale.fromLanguageTags("nb", "nb-NO")),
+        Arguments.of(LOW, "ms", ResolvedLocale.fromLanguageTags("id", "id-ID")),
+        Arguments.of(LOW, "ms-MY", ResolvedLocale.fromLanguageTags("id", "id-ID")),
+        Arguments.of(LOW, "mn-KZ", ResolvedLocale.fromLanguageTags("ru", "ru-KZ")),
+        Arguments.of(LOW, "mn", ResolvedLocale.fromLanguageTags("ru", "ru-RU")),
+        Arguments.of(LOW, "eu-ES", ResolvedLocale.fromLanguageTags("es", "es-ES")),
+        Arguments.of(LOW, "ca-AD", ResolvedLocale.fromLanguageTags("es", "es-ES")));
+  }
+
+  @Test
+  @Disabled
+  public void testDistance() {
+    System.out.println(
+        LocaleDistance.INSTANCE.testOnlyDistance(
+            ULocale.forLanguageTag("eu-ES"),
+            ULocale.forLanguageTag("es"),
+            LocaleDistance.INSTANCE.getDefaultScriptDistance(),
+            FavorSubtag.LANGUAGE));
+    System.out.println(
+        LocaleDistance.INSTANCE.testOnlyDistance(
+            ULocale.forLanguageTag("ca-AD"),
+            ULocale.forLanguageTag("es"),
+            LocaleDistance.INSTANCE.getDefaultScriptDistance(),
+            FavorSubtag.LANGUAGE));
+    System.out.println(
+        LocaleDistance.INSTANCE.testOnlyDistance(
+            ULocale.forLanguageTag("da"),
+            ULocale.forLanguageTag("nb"),
+            LocaleDistance.INSTANCE.getDefaultScriptDistance(),
+            FavorSubtag.LANGUAGE));
+    System.out.println(
+        LocaleDistance.INSTANCE.testOnlyDistance(
+            ULocale.forLanguageTag("ms"),
+            ULocale.forLanguageTag("id"),
+            LocaleDistance.INSTANCE.getDefaultScriptDistance(),
+            FavorSubtag.LANGUAGE));
   }
 }


### PR DESCRIPTION
We are hitting an issue with the current setup, where the default behavior for the ICU `LocaleMatcher` promotes locales which are too distant from what we consider as an acceptable best match.

Examples:
- Norwegian Bokmål `nb` is promoted as best matching locale for Danish `da`.
- Indonesian `id` gets promoted as best matching locale for Malay `ms`.
- Russian `ru` gets promoted as best matching locale for Kazakh `kk` and Mongolian `mn`.

We would like to enable some level of control over the matching logic. We suggest adding a new `minimumLocaleAffinity` configuration option, which builds on the locale affinity logic implemented previously.

In order to not break existing integrations, we need to set a default value for this new configuration option. We decided to set it to `MUTUALLY_INTELLIGIBLE` define [over here](https://github.com/spotify/java-locales/blob/main/locales-common/src/main/java/com/spotify/i18n/locales/common/model/LocaleAffinity.java#L42-L46).